### PR TITLE
Rework can message formatting functions

### DIFF
--- a/can_common.c
+++ b/can_common.c
@@ -24,14 +24,14 @@ static void write_timestamp_3bytes(uint32_t timestamp, can_msg_t *output)
 }
 
 bool build_general_cmd_msg(uint32_t timestamp,
-                           uint8_t cmd,
+                           enum GEN_CMD cmd,
                            can_msg_t *output)
 {
     if (!output) { return false; }
 
     output->sid = MSG_GENERAL_CMD | BOARD_UNIQUE_ID;
     write_timestamp_3bytes(timestamp, output);
-    output->data[3] = cmd;
+    output->data[3] = (uint8_t) cmd;
     output->data_len = 4;   // 3 bytes timestamp, 1 byte data
 
     return true;
@@ -72,7 +72,7 @@ bool build_debug_printf(uint8_t *input_data,
 }
 
 bool build_valve_cmd_msg(uint32_t timestamp,
-                         uint8_t valve_cmd,
+                         enum VALVE_STATE valve_cmd,
                          uint16_t message_type,  // vent or injector
                          can_msg_t *output)
 {
@@ -85,15 +85,15 @@ bool build_valve_cmd_msg(uint32_t timestamp,
     output->sid = message_type | BOARD_UNIQUE_ID;
     write_timestamp_3bytes(timestamp, output);
 
-    output->data[3] = valve_cmd;
+    output->data[3] = (uint8_t) valve_cmd;
     output->data_len = 4;   // 3 bytes timestamp, 1 byte data
 
     return true;
 }
 
 bool build_valve_stat_msg(uint32_t timestamp,
-                          uint8_t valve_state,
-                          uint8_t req_valve_state,
+                          enum VALVE_STATE valve_state,
+                          enum VALVE_STATE req_valve_state,
                           uint16_t message_type,    // vent or injector
                           can_msg_t *output)
 {
@@ -106,8 +106,8 @@ bool build_valve_stat_msg(uint32_t timestamp,
     output->sid = message_type | BOARD_UNIQUE_ID;
     write_timestamp_3bytes(timestamp, output);
 
-    output->data[3] = valve_state;
-    output->data[4] = req_valve_state;
+    output->data[3] = (uint8_t) valve_state;
+    output->data[4] = (uint8_t) req_valve_state;
     output->data_len = 5;   // 3 bytes timestamp, 2 bytes data
 
     return true;
@@ -116,7 +116,7 @@ bool build_valve_stat_msg(uint32_t timestamp,
 // This might need to be made more granular - it doesn't quite hide
 // the data layout properly.
 bool build_board_stat_msg(uint32_t timestamp,
-                          uint8_t error_code,
+                          enum BOARD_STATUS error_code,
                           uint8_t *error_data,
                           uint8_t error_data_len,
                           can_msg_t *output)
@@ -128,7 +128,7 @@ bool build_board_stat_msg(uint32_t timestamp,
     output->sid = MSG_GENERAL_BOARD_STATUS | BOARD_UNIQUE_ID;
     write_timestamp_3bytes(timestamp, output);
 
-    output->data[3] = error_code;
+    output->data[3] = (uint8_t) error_code;
     for (int i = 0; i < error_data_len; ++i) {
         // error data goes in message bytes 4-7
         output->data[4 + i] = error_data[i];
@@ -141,7 +141,7 @@ bool build_board_stat_msg(uint32_t timestamp,
 }
 
 bool build_imu_data_msg(uint16_t message_type,
-                        uint16_t timestamp,   // acc, gyro, mag
+                        uint32_t timestamp,   // acc, gyro, mag
                         uint16_t *imu_data,   // x, y, z
                         can_msg_t *output)
 {
@@ -174,8 +174,8 @@ bool build_imu_data_msg(uint16_t message_type,
     return true;
 }
 
-bool build_analog_data_msg(uint16_t timestamp,
-                           uint8_t sensor_id,
+bool build_analog_data_msg(uint32_t timestamp,
+                           enum SENSOR_ID sensor_id,
                            uint16_t sensor_data,
                            can_msg_t *output)
 {
@@ -184,7 +184,7 @@ bool build_analog_data_msg(uint16_t timestamp,
     output->sid = MSG_SENSOR_ANALOG | BOARD_UNIQUE_ID;
     write_timestamp_2bytes(timestamp, output);
 
-    output->data[2] = sensor_id;
+    output->data[2] = (uint8_t) sensor_id;
     output->data[3] = (sensor_data >> 8) & 0xff;
     output->data[4] = (sensor_data >> 0) & 0xff;
 
@@ -313,7 +313,7 @@ bool get_imu_data(const can_msg_t *msg, uint16_t *output_x, uint16_t *output_y, 
     return true;
 }
 
-bool get_analog_data(const can_msg_t *msg, uint8_t *sensor_id, uint16_t *output_data)
+bool get_analog_data(const can_msg_t *msg, enum SENSOR_ID *sensor_id, uint16_t *output_data)
 {
     if (!msg) { return false; }
     if (!output_data) { return false; }

--- a/can_common.h
+++ b/can_common.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "can.h"
+#include "message_types.h"
 
 /*
  * Debug levels for the debugging messages (MSG_DEBUG_MSG). Lower
@@ -51,7 +52,7 @@ typedef enum {
 * message_types.h
 */
 bool build_general_cmd_msg(uint32_t timestamp,
-                           uint8_t cmd,
+                           enum GEN_CMD cmd,
                            can_msg_t *output);
 
 bool build_debug_msg(uint32_t timestamp,
@@ -65,7 +66,7 @@ bool build_debug_printf(uint8_t *data,
  * Used to send injector and vent commands
  */
 bool build_valve_cmd_msg(uint32_t timestamp,
-                         uint8_t valve_cmd,      // VALVE_STATE
+                         enum VALVE_STATE valve_cmd,
                          uint16_t message_type,  // vent or injector
                          can_msg_t *output);
 
@@ -73,8 +74,8 @@ bool build_valve_cmd_msg(uint32_t timestamp,
 * Used to send injector/vent status: current and desired
 */
 bool build_valve_stat_msg(uint32_t timestamp,
-                          uint8_t valve_state,      // VALVE_STATE
-                          uint8_t req_valve_state,  // VALVE_STATE
+                          enum VALVE_STATE valve_state,
+                          enum VALVE_STATE req_valve_state,
                           uint16_t message_type,    // vent or injector
                           can_msg_t *output);
 
@@ -84,7 +85,7 @@ bool build_valve_stat_msg(uint32_t timestamp,
 * This function may need to be modified to better hide the internals.
 */
 bool build_board_stat_msg(uint32_t timestamp,
-                          uint8_t error_code,
+                          enum BOARD_STATUS error_code,
                           uint8_t *error_data,
                           uint8_t error_data_len,
                           can_msg_t *output);
@@ -94,7 +95,7 @@ bool build_board_stat_msg(uint32_t timestamp,
 * of 3 values is sent (X, Y, and Z axes).
 */
 bool build_imu_data_msg(uint16_t message_type,  // acc, gyro, mag
-                        uint16_t timestamp,
+                        uint32_t timestamp,
                         uint16_t *imu_data,     // x, y, z
                         can_msg_t *output);
 
@@ -103,8 +104,8 @@ bool build_imu_data_msg(uint16_t message_type,  // acc, gyro, mag
 * not nailed down at this point and will likely differ based on the
 * sensor id.
 */
-bool build_analog_data_msg(uint16_t timestamp,
-                           uint8_t sensor_id,
+bool build_analog_data_msg(uint32_t timestamp,
+                           enum SENSOR_ID sensor_id,
                            uint16_t sensor_data,
                            can_msg_t *output);
 
@@ -161,7 +162,7 @@ bool get_imu_data(const can_msg_t *msg,
  * the input is invalid.
  */
 bool get_analog_data(const can_msg_t *msg,
-                     uint8_t *sensor_id,
+                     enum SENSOR_ID *sensor_id,
                      uint16_t *output_data);
 
 /*

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -11,6 +11,7 @@ VPATH +=../../
 VPATH +=../../util/
 
 DEFINES+=-DBOARD_UNIQUE_ID=3
+DEFINES+=-DTARGET_LOCAL
 
 program_name=unit_tests
 

--- a/tests/unit/build_can_message.c
+++ b/tests/unit/build_can_message.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 //if this test is running on hardware, don't actually print anything
-#ifndef NO_PRINTF
+#ifdef TARGET_LOCAL
 #define REPORT_FAIL(x) printf("%s: Fail: %s\n", __FUNCTION__, x)
 #else
 #define REPORT_FAIL(x)
@@ -17,28 +17,158 @@ static bool test_general_command(void)
     uint8_t input_data = 0x74;
     can_msg_t output;
 
+    bool ret = true;
+
+    // Test illegal args
+    if (build_general_cmd_msg(timestamp, input_data, NULL)) {
+        REPORT_FAIL("Message built with null output");
+        ret = false;
+    }
+
     // make sure we don't get an error creating the message
-    build_general_cmd_msg(timestamp, input_data, &output);
+    if (!build_general_cmd_msg(timestamp, input_data, &output)) {
+        REPORT_FAIL("Error building message");
+        ret = false;
+    }
 
     // check that the data length is 4
     if (output.data_len != 4) {
         REPORT_FAIL("Wrong data_len generated");
-        return false;
+        ret = false;
     }
     // check that the timestamp was copied across properly
-    if (output.data[0] != 0xfe ||
-        output.data[1] != 0xba ||
-        output.data[2] != 0xbe) {
+    // only bottom 3 bytes of original should be copied
+    if (get_timestamp(&output) != (timestamp & 0xffffff)) {
         REPORT_FAIL("Timestamp copied wrong");
-        return false;
+        ret = false;
     }
     // check that the SID is proper. Note that the Makefile defines
     // the unique ID to be 0x3
     if (output.sid != 0x063) {
         REPORT_FAIL("SID compare failed");
-        return false;
+        ret = false;
     }
-    return true;
+
+    return ret;
+}
+
+static bool test_valve_cmd(void)
+{
+    uint32_t timestamp = 0x12345678;
+    can_msg_t output;
+
+    bool ret = true;
+
+    // test illegal args
+    if (build_valve_cmd_msg(timestamp, VALVE_OPEN, MSG_DEBUG_MSG, &output)) {
+        REPORT_FAIL("Valve cmd built with invalid message type");
+        ret = false;
+    }
+    if (build_valve_cmd_msg(timestamp, VALVE_OPEN, MSG_INJ_VALVE_CMD, NULL)) {
+        REPORT_FAIL("Message built with null output");
+        ret = false;
+    }
+
+    // test nominal behaviour
+    if (!build_valve_cmd_msg(timestamp, VALVE_OPEN, MSG_INJ_VALVE_CMD, &output)) {
+        REPORT_FAIL("Error building message");
+        ret = false;
+    }
+    if (output.data_len != 4) {
+        REPORT_FAIL("Data length is wrong");
+        ret = false;
+    }
+    if (get_timestamp(&output) != (timestamp & 0xffffff)) {
+        REPORT_FAIL("Timestamp copied wrong");
+        ret = false;
+    }
+    if (get_curr_valve_state(&output) != -1) {
+        REPORT_FAIL("Got current valve state from a command message");
+        ret = false;
+    }
+    if (get_req_valve_state(&output) != VALVE_OPEN) {
+        REPORT_FAIL("Valve data copied incorrectly");
+        ret = false;
+    }
+
+    return ret;
+}
+
+static bool test_valve_stat(void)
+{
+    uint32_t timestamp = 0x12345678;
+    can_msg_t output;
+
+    bool ret = true;
+
+    // test illegal args
+    if (build_valve_stat_msg(timestamp, VALVE_OPEN, VALVE_UNK, MSG_DEBUG_MSG, &output)) {
+        REPORT_FAIL("Valve cmd built with invalid message type");
+        ret = false;
+    }
+    if (build_valve_stat_msg(timestamp, VALVE_OPEN, VALVE_UNK, MSG_INJ_VALVE_STATUS, NULL)) {
+        REPORT_FAIL("Message built with null output");
+        ret = false;
+    }
+
+    // test nominal behaviour
+    if (!build_valve_stat_msg(timestamp, VALVE_OPEN, VALVE_CLOSED, MSG_INJ_VALVE_STATUS, &output)) {
+        REPORT_FAIL("Error building message");
+        ret = false;
+    }
+    if (output.data_len != 5) {
+        REPORT_FAIL("Data length is wrong");
+        ret = false;
+    }
+    if (get_timestamp(&output) != (timestamp & 0xffffff)) {
+        REPORT_FAIL("Timestamp copied wrong");
+        ret = false;
+    }
+    if (get_curr_valve_state(&output) != VALVE_OPEN) {
+        REPORT_FAIL("Current valve state copied wrong");
+        ret = false;
+    }
+    if (get_req_valve_state(&output) != VALVE_CLOSED) {
+        REPORT_FAIL("Requested valve state copied wrong");
+        ret = false;
+    }
+
+    return ret;
+}
+
+static bool test_board_stat(void)
+{
+    uint32_t timestamp = 0x12345678;
+    uint8_t error_data[2] = { 0x32, 0x10 };
+    uint8_t error_data_len = 2;
+    can_msg_t output;
+
+    bool ret = true;
+
+    // test illegal args
+    if (build_board_stat_msg(timestamp, E_NOMINAL, NULL, error_data_len, &output)) {
+        REPORT_FAIL("Built message with null input data");
+        ret = false;
+    }
+    if (build_board_stat_msg(timestamp, E_NOMINAL, error_data, error_data_len, NULL)) {
+        REPORT_FAIL("Built message with null output");
+        ret = false;
+    }
+
+    // test nominal behaviour
+    if (!build_board_stat_msg(timestamp, E_BATT_UNDER_VOLTAGE, error_data, error_data_len, &output)) {
+        REPORT_FAIL("Error building message");
+        ret = false;
+    }
+    if (get_timestamp(&output) != (timestamp & 0xffffff)) {
+        REPORT_FAIL("Timestamp copied wrong");
+        ret = false;
+    }
+    if (output.data_len != 6) {
+        REPORT_FAIL("Data length is wrong");
+    }
+
+    return ret;
 }
 
 static bool test_debug_printf(void)
@@ -48,12 +178,33 @@ static bool test_debug_printf(void)
         'u', 'n', 'i', 't',
         't', 'e', 's', 't'
     };
+
     can_msg_t output;
-    build_debug_printf(input_data, &output);
+    bool ret = true;
+
+    // Test illegal args
+    if (build_debug_printf(NULL, &output)) {
+        REPORT_FAIL("Message built with null data");
+        ret = false;
+    }
+
+    if (build_debug_printf(input_data, NULL)) {
+        REPORT_FAIL("Message built with null output");
+        ret = false;
+    }
+
+    if (!build_debug_printf(input_data, &output)) {
+        REPORT_FAIL("Error building message");
+        ret = false;
+    }
     // check the SID
     if (output.sid != 0x1E3) {
         REPORT_FAIL("SID compare failed");
-        return false;
+        ret = false;
+    }
+    if (get_timestamp(&output) != 0) {
+        REPORT_FAIL("Timestamp copied wrong");
+        ret = false;
     }
     // check the outputted data
     if (output.data[0] != 'u' ||
@@ -65,55 +216,151 @@ static bool test_debug_printf(void)
         output.data[6] != 's' ||
         output.data[7] != 't') {
         REPORT_FAIL("printf data not copied over properly");
-        return false;
+        ret = false;
     }
-    return true;
+    return ret;
 }
 
-static bool test_sensor_acc(void)
+static bool test_sensor_imu(void)
 {
     uint16_t input_data[3] = {
         0xa749, 0x6664, 0x1008
     };
     can_msg_t output;
     uint32_t timestamp = 0x12345678;
-    build_imu_data_msg(MSG_SENSOR_ACC, timestamp, input_data, &output);
-    
+    bool ret = true;
+
+    // test illegal args
+    if (build_imu_data_msg(MSG_GENERAL_CMD, timestamp, input_data, &output)) {
+        REPORT_FAIL("IMU message created with invalid message type");
+        ret = false;
+    }
+    if (build_imu_data_msg(MSG_SENSOR_ACC, timestamp, NULL, &output)) {
+        REPORT_FAIL("Message built with null input data");
+        ret = false;
+    }
+    if (build_imu_data_msg(MSG_SENSOR_ACC, timestamp, input_data, NULL)) {
+        REPORT_FAIL("Message built with null output");
+        ret = false;
+    }
+
+    // test nominal behaviour
+    if (!build_imu_data_msg(MSG_SENSOR_ACC, timestamp, input_data, &output)) {
+        REPORT_FAIL("Error building message");
+        ret = false;
+    }
     if (output.sid != 0x583) {
         REPORT_FAIL("SID compare failed");
-        printf("sid: %x\n", output.sid);
-        return false;
+        ret = false;
     }
-    if (output.data[0] != 0x56 ||
-        output.data[1] != 0x78) {
+    if (output.data_len != 8) {
+        REPORT_FAIL("Data length copied wrong");
+        ret = false;
+    }
+    if (get_timestamp(&output) != (timestamp & 0xffff)) {
         REPORT_FAIL("Timestamp copied wrong");
-        return false;
+        ret = false;
     }
-    if (output.data[2] != 0xa7 ||
-        output.data[3] != 0x49 ||
-        output.data[4] != 0x66 ||
-        output.data[5] != 0x64 ||
-        output.data[6] != 0x10 ||
-        output.data[7] != 0x08) {
-        REPORT_FAIL("Sensor Data copied wrong");
-        return false;
+
+    uint16_t output_x, output_y, output_z;
+    if (!get_imu_data(&output, &output_x, &output_y, &output_z)) {
+        REPORT_FAIL("Failed to retrieve sensor data");
+        ret = false;
     }
-    return true;
+    if (output_z != 0x1008) {
+        REPORT_FAIL("Z data is incorrect");
+        ret = false;
+    }
+    if (output_y != 0x6664) {
+        REPORT_FAIL("Y data is incorrect");
+        ret = false;
+    }
+    if (output_x != 0xa749) {
+        REPORT_FAIL("X data is incorrect");
+        ret = false;
+    }
+    return ret;
 }
 
+static bool test_sensor_analog(void)
+{
+    uint16_t data = 0x380c;
+    uint32_t timestamp = 0x12345678;
+    can_msg_t output;
+    bool ret = true;
+
+    // test illegal args
+    if (build_analog_data_msg(timestamp, SENSOR_BARO, data, NULL)) {
+        REPORT_FAIL("Message built with null output");
+        ret = false;
+    }
+
+    // test nominal behaviour
+    if (!build_analog_data_msg(timestamp, SENSOR_BARO, data, &output)) {
+        REPORT_FAIL("Error building message");
+        ret = false;
+    }
+    if (output.sid != 0x6a3) {
+        REPORT_FAIL("SID compare failed");
+        ret = false;
+    }
+    if (output.data_len != 5) {
+        REPORT_FAIL("Data length copied wrong");
+        ret = false;
+    }
+    if (get_timestamp(&output) != (timestamp & 0xffff)) {
+        REPORT_FAIL("Timestamp copied wrong");
+        ret = false;
+    }
+
+    uint16_t output_data;
+    uint8_t output_sensor_id;
+    if (!get_analog_data(&output, &output_sensor_id, &output_data)) {
+        REPORT_FAIL("Failed to retrieve sensor data");
+        ret = false;
+    }
+    if (output_data != data) {
+        REPORT_FAIL("Analog data is incorrect");
+        ret = false;
+    }
+    if (output_sensor_id != SENSOR_BARO) {
+        REPORT_FAIL("Sensor id is incorrect");
+        ret = false;
+    }
+    return ret;
+}
 
 bool test_build_can_message(void)
 {
+    bool ret = true;
     if (!test_general_command()) {
-        printf(__FILE__ ": Error, test_general_command returned false\n");
-        return false;
-    } else if (!test_debug_printf()) {
+        REPORT_FAIL("test_general_command returned false");
+        ret = false;
+    }
+    if (!test_valve_cmd()) {
+        REPORT_FAIL("test_valve_cmd returned false");
+        ret = false;
+    }
+    if (!test_valve_stat()) {
+        REPORT_FAIL("test_valve_stat returned false");
+        ret = false;
+    }
+    if (!test_board_stat()) {
+        REPORT_FAIL("test_board_stat returned false");
+        ret = false;
+    }
+    if (!test_debug_printf()) {
         REPORT_FAIL("test_debug_printf returned false");
-        return false;
-    } else if (!test_sensor_acc()) {
+        ret = false;
+    }
+    if (!test_sensor_imu()) {
         REPORT_FAIL("test_sensor_acc returned false");
-        return false;
+        ret = false;
+    }
+    if (!test_sensor_analog()) {
+        REPORT_FAIL("test_sensor_analog returned false");
+        ret = false;
     }
 
-    return true;
+    return ret;
 }

--- a/tests/unit/build_can_message.c
+++ b/tests/unit/build_can_message.c
@@ -314,7 +314,7 @@ static bool test_sensor_analog(void)
     }
 
     uint16_t output_data;
-    uint8_t output_sensor_id;
+    enum SENSOR_ID output_sensor_id;
     if (!get_analog_data(&output, &output_sensor_id, &output_data)) {
         REPORT_FAIL("Failed to retrieve sensor data");
         ret = false;

--- a/tests/unit/can_common_tests.c
+++ b/tests/unit/can_common_tests.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 //if this test is running on hardware, don't actually print anything
-#ifndef NO_PRINTF
+#ifdef TARGET_LOCAL
 #define REPORT_FAIL(x) printf("%s: Fail: %s\n", __FUNCTION__, x)
 #else
 #define REPORT_FAIL(x)
@@ -140,7 +140,7 @@ static bool test_debug_printf(void)
 bool test_can_common_functions(void)
 {
     if (!test_debug_printf()) {
-        printf("%s: Error, test_debug_printf returned false\n", __FUNCTION__);
+        REPORT_FAIL("Error, test_debug_printf returned false\n");
         return false;
     }
 

--- a/tests/unit/can_common_tests.c
+++ b/tests/unit/can_common_tests.c
@@ -12,155 +12,37 @@
 #define REPORT_FAIL(x)
 #endif
 
-static bool test_get_message_type(void)
-{
-    can_msg_t output;
-    uint8_t input_data[8];
-    // for each type of message, generate a message of that type, then
-    // check that get_message_type returns that. I'm lazy, I don't
-    // want to type all that, so here comes a sketchy macro
-#define CHECK_GET_MESSAGE_TYPE(x)                                       \
-    do {                                                                \
-        if (!build_can_message((x), 0, input_data, &output)) {          \
-            REPORT_FAIL("fail on build_can_message"); \
-            return false;                                               \
-        }                                                               \
-        if ((x) != get_message_type(&output)) {                         \
-            REPORT_FAIL("fail on get_message_type"); \
-            return false;                                               \
-        }                                                               \
-    } while(0)
-
-    CHECK_GET_MESSAGE_TYPE(MSG_GENERAL_CMD);
-    CHECK_GET_MESSAGE_TYPE(MSG_VENT_VALVE_CMD);
-    CHECK_GET_MESSAGE_TYPE(MSG_INJ_VALVE_CMD);
-    CHECK_GET_MESSAGE_TYPE(MSG_DEBUG_MSG);
-    CHECK_GET_MESSAGE_TYPE(MSG_DEBUG_PRINTF);
-    CHECK_GET_MESSAGE_TYPE(MSG_VENT_VALVE_STATUS);
-    CHECK_GET_MESSAGE_TYPE(MSG_INJ_VALVE_STATUS);
-    CHECK_GET_MESSAGE_TYPE(MSG_GENERAL_BOARD_STATUS);
-    CHECK_GET_MESSAGE_TYPE(MSG_SENSOR_ACC);
-    CHECK_GET_MESSAGE_TYPE(MSG_SENSOR_GYRO);
-    CHECK_GET_MESSAGE_TYPE(MSG_SENSOR_MAG);
-    CHECK_GET_MESSAGE_TYPE(MSG_SENSOR_ANALOG);
-    CHECK_GET_MESSAGE_TYPE(MSG_LEDS_ON);
-    CHECK_GET_MESSAGE_TYPE(MSG_LEDS_OFF);
-
-    return true;
-}
-
-static bool test_is_sensor_data(void)
-{
-    can_msg_t output;
-    uint8_t input_data[8];
-#define CHECK_IS_NOT_SENSOR_DATA(x)                                     \
-    do {                                                                \
-        if (!build_can_message((x), 0, input_data, &output)) {          \
-            REPORT_FAIL("fail on build_can_message"); \
-            return false;                                               \
-        }                                                               \
-        if (is_sensor_data(&output)) {                                  \
-            REPORT_FAIL("fail on is_sensor_data"); \
-            return false;                                               \
-        }                                                               \
-    } while(0)
-#define CHECK_IS_SENSOR_DATA(x)                                         \
-    do {                                                                \
-        if (!build_can_message((x), 0, input_data, &output)) {          \
-            REPORT_FAIL("fail on build_can_message"); \
-            return false;                                               \
-        }                                                               \
-        if (!is_sensor_data(&output)) {                                 \
-            REPORT_FAIL("fail on is_sensor_data"); \
-            return false;                                               \
-        }                                                               \
-    } while(0)
-
-    CHECK_IS_NOT_SENSOR_DATA(MSG_GENERAL_CMD);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_VENT_VALVE_CMD);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_INJ_VALVE_CMD);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_DEBUG_MSG);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_DEBUG_PRINTF);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_VENT_VALVE_STATUS);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_INJ_VALVE_STATUS);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_GENERAL_BOARD_STATUS);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_LEDS_ON);
-    CHECK_IS_NOT_SENSOR_DATA(MSG_LEDS_OFF);
-
-    CHECK_IS_SENSOR_DATA(MSG_SENSOR_ACC);
-    CHECK_IS_SENSOR_DATA(MSG_SENSOR_GYRO);
-    CHECK_IS_SENSOR_DATA(MSG_SENSOR_MAG);
-    CHECK_IS_SENSOR_DATA(MSG_SENSOR_ANALOG);
-
-    return true;
-}
 
 static bool test_message_debug_level(void)
 {
     can_msg_t output;
     uint8_t input_data[8];
-#define CHECK_IS_NOT_DEBUG_MSG(x)                                       \
-    do {                                                                \
-        if (!build_can_message((x), 0, input_data, &output)) {          \
-            REPORT_FAIL("fail on build_can_message"); \
-            return false;                                               \
-        }                                                               \
-        if (NONE != message_debug_level(&output)) {                             \
-            REPORT_FAIL("fail on message_debug_level"); \
-            return false;                                               \
-        }                                                               \
-    } while(0)
-
-    CHECK_IS_NOT_DEBUG_MSG(MSG_GENERAL_CMD);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_VENT_VALVE_CMD);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_INJ_VALVE_CMD);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_DEBUG_PRINTF);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_VENT_VALVE_STATUS);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_INJ_VALVE_STATUS);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_GENERAL_BOARD_STATUS);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_SENSOR_ACC);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_SENSOR_GYRO);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_SENSOR_MAG);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_SENSOR_ANALOG);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_LEDS_ON);
-    CHECK_IS_NOT_DEBUG_MSG(MSG_LEDS_OFF);
 
     // Check for ERROR
     input_data[0] = 0x10;
-    if (!build_can_message(MSG_DEBUG_MSG, 0, input_data, &output)) {
-        REPORT_FAIL("fail on build_can_message when level is ERROR");
-        return false;
-    }
+    build_debug_msg(0, input_data, &output);
     if (ERROR != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is ERROR");
         return false;
     }
+
     // Check for WARN
     input_data[0] = 0x20;
-    if (!build_can_message(MSG_DEBUG_MSG, 0, input_data, &output)) {
-        REPORT_FAIL("fail on build_can_message when level is WARN");
-        return false;
-    }
+    build_debug_msg(0, input_data, &output);
     if (WARN != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is WARN");
         return false;
     }
     // Check for INFO
     input_data[0] = 0x30;
-    if (!build_can_message(MSG_DEBUG_MSG, 0, input_data, &output)) {
-        REPORT_FAIL("fail on build_can_message when level is INFO");
-        return false;
-    }
+    build_debug_msg(0, input_data, &output);
     if (INFO != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is INFO");
         return false;
     }
     // Check for DEBUG
     input_data[0] = 0x40;
-    if (!build_can_message(MSG_DEBUG_MSG, 0, input_data, &output)) {
-        REPORT_FAIL("fail on build_can_message when level is DEBUG");
-        return false;
-    }
+    build_debug_msg(0, input_data, &output);
     if (DEBUG != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is DEBUG");
         return false;
@@ -257,17 +139,8 @@ static bool test_debug_printf(void)
 
 bool test_can_common_functions(void)
 {
-    if (!test_get_message_type()) {
-        REPORT_FAIL("Error, test_get_message_type returned false");
-        return false;
-    } else if (!test_is_sensor_data()) {
-        REPORT_FAIL("Error, test_is_sensor_data returned false");
-        return false;
-    } else if (!test_message_debug_level()) {
-        REPORT_FAIL("Error, test_message_debug_level returned false");
-        return false;
-    } else if (!test_debug_printf()) {
-        REPORT_FAIL("Error, test_debug_printf returned false");
+    if (!test_debug_printf()) {
+        printf("%s: Error, test_debug_printf returned false\n", __FUNCTION__);
         return false;
     }
 

--- a/tests/unit/can_common_tests.c
+++ b/tests/unit/can_common_tests.c
@@ -17,37 +17,50 @@ static bool test_message_debug_level(void)
 {
     can_msg_t output;
     uint8_t input_data[8];
+    bool ret = true;
 
     // Check for ERROR
     input_data[0] = 0x10;
-    build_debug_msg(0, input_data, &output);
+    if (!build_debug_msg(0, input_data, &output)) {
+        REPORT_FAIL("fail on build_can_message when level is ERROR");
+        ret = false;
+    }
     if (ERROR != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is ERROR");
-        return false;
+        ret = false;
     }
 
     // Check for WARN
     input_data[0] = 0x20;
-    build_debug_msg(0, input_data, &output);
+    if (!build_debug_msg(0, input_data, &output)) {
+        REPORT_FAIL("fail on build_can_message when level is WARN");
+        ret = false;
+    }
     if (WARN != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is WARN");
-        return false;
+        ret = false;
     }
     // Check for INFO
     input_data[0] = 0x30;
-    build_debug_msg(0, input_data, &output);
+    if (!build_debug_msg(0, input_data, &output)) {
+        REPORT_FAIL("fail on build_can_message when level is INFO");
+        ret = false;
+    }
     if (INFO != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is INFO");
-        return false;
+        ret = false;
     }
     // Check for DEBUG
     input_data[0] = 0x40;
-    build_debug_msg(0, input_data, &output);
+    if (!build_debug_msg(0, input_data, &output)) {
+        REPORT_FAIL("fail on build_can_message when level is DEBUG");
+        ret = false;
+    }
     if (DEBUG != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is DEBUG");
-        return false;
+        ret = false;
     }
-    return true;
+    return ret;
 }
 
 static bool test_debug_printf(void)
@@ -55,12 +68,13 @@ static bool test_debug_printf(void)
     // test that debug printf works, and can write out "does this work lol?" (which should take 3 messages to write)
     can_msg_t output;
     const char *message = "does this work lol?";
+    bool ret = true;
 
     // this call should put "does thi" in output, and should set message to "s work lol?"
     message = build_printf_can_message(message, &output);
     if (output.data_len != 8) {
         REPORT_FAIL("First call to build_printf_can_message didn't set data_len properly");
-        return false;
+        ret = false;
     } else if (output.data[0] != 'd' ||
                output.data[1] != 'o' ||
                output.data[2] != 'e' ||
@@ -70,20 +84,20 @@ static bool test_debug_printf(void)
                output.data[6] != 'h' ||
                output.data[7] != 'i') {
         REPORT_FAIL("First call to build_printf_can_message didn't set data properly");
-        return false;
+        ret = false;
     } else if (strcmp(message, "s work lol?")) {
         REPORT_FAIL("First call to build_printf_can_message didn't set message properly");
-        return false;
+        ret = false;
     } else if (output.sid != 0x1E3) {
         REPORT_FAIL("First call to build_printf_can_message didn't set sid properly");
-        return false;
+        ret = false;
     }
 
     // this call should put "s work l" in output, and should set message to "ol?"
     message = build_printf_can_message(message, &output);
     if (output.data_len != 8) {
         REPORT_FAIL("Second call to build_printf_can_message didn't set data_len properly");
-        return false;
+        ret = false;
     } else if (output.data[0] != 's' ||
                output.data[1] != ' ' ||
                output.data[2] != 'w' ||
@@ -93,58 +107,47 @@ static bool test_debug_printf(void)
                output.data[6] != ' ' ||
                output.data[7] != 'l') {
         REPORT_FAIL("Second call to build_printf_can_message didn't set data properly");
-        return false;
+        ret = false;
     } else if (strcmp(message, "ol?")) {
         REPORT_FAIL("Second call to build_printf_can_message didn't set message properly");
-        return false;
+        ret = false;
     } else if (output.sid != 0x1E3) {
         REPORT_FAIL("Second call to build_printf_can_message didn't set sid properly");
-        return false;
+        ret = false;
     }
 
     // this call should put "ol?" in output, and should set message to '\0'
     message = build_printf_can_message(message, &output);
     if (output.data_len != 3) {
         REPORT_FAIL("Third call to build_printf_can_message didn't set data_len properly");
-        return false;
+        ret = false;
     } else if (output.data[0] != 'o' ||
                output.data[1] != 'l' ||
                output.data[2] != '?') {
         REPORT_FAIL("Third call to build_printf_can_message didn't set data properly");
-        return false;
+        ret = false;
     } else if (*message != '\0') {
         REPORT_FAIL("Third call to build_printf_can_message didn't set message properly");
-        return false;
+        ret = false;
     } else if (output.sid != 0x1E3) {
         REPORT_FAIL("Third call to build_printf_can_message didn't set sid properly");
-        return false;
+        ret = false;
     }
 
     // this call should put nothing in output, and shouldn't change message
     message = build_printf_can_message(message, &output);
     if (output.data_len != 0) {
         REPORT_FAIL("Fourth call to build_printf_can_message didn't set data_len properly");
-        return false;
+        ret = false;
     } else if (*message != '\0') {
         REPORT_FAIL("Fourth call to build_printf_can_message didn't set message properly");
-        return false;
+        ret = false;
     } else if (output.sid != 0x1E3) {
         REPORT_FAIL("Fourth call to build_printf_can_message didn't set sid properly");
-        return false;
+        ret = false;
     }
 
-
-    return true;
-}
-
-bool test_can_common_functions(void)
-{
-    if (!test_debug_printf()) {
-        REPORT_FAIL("Error, test_debug_printf returned false\n");
-        return false;
-    }
-
-    return true;
+    return ret;
 }
 
 bool test_debug_macro(void)
@@ -155,33 +158,55 @@ bool test_debug_macro(void)
     int linum = __LINE__ + 1;
     DEBUG(ERROR, 0, output);
 
+    bool ret = true;
+
     if (output.sid != 0x183) {
         // Check that the SID was set correctly. Note this assumes
         // that the unit tests assign BOARD_UNIQUE_ID to 0x03
-        return false;
+        ret = false;
     } else if (output.data_len != 8) {
         // Check that the proper amount of data was written out
-        return false;
+        ret = false;
     } else if (output.data[3] != (0x10 + ((linum >> 8) & 0xF))) {
         // Check that ERROR (0x01) was put in the top nibble, and that
         // bits [11:8] of linum (the line number of where that DEBUG
         // call is above) was put in the bottom nibble
-        return false;
+        ret = false;
     } else if (output.data[4] != (linum & 0xFF)) {
         // check that the bottom byte of linum was put in this byte of
         // the data
-        return false;
+        ret = false;
     } else if (message_debug_level(&output) != ERROR) {
         // Check the debug level. This is more of a test that the
         // message_debug_level function works, since we already
         // checked that the top nibble of data[3] was 0x01
-        return false;
+        ret = false;
     } else if (get_message_type(&output) != MSG_DEBUG_MSG) {
         // Check the message type. Again, we've already checked the
         // SID, so this is more of a check of the get_message_type
         // function
-        return false;
+        ret = false;
     }
 
-    return true;
+    return ret;
 }
+
+bool test_can_common_functions(void)
+{
+    bool ret = true;
+    if (!test_message_debug_level()) {
+        REPORT_FAIL("Error, test_message_debug_level returned false");
+        ret = false;
+    }
+    if (!test_debug_printf()) {
+        REPORT_FAIL("Error, test_debug_printf returned false");
+        ret = false;
+    }
+    if (!test_debug_macro()) {
+        REPORT_FAIL("Error, test_debug_macro returned false");
+        ret = false;
+    }
+
+    return ret;
+}
+

--- a/tests/unit/target_pic18.X/nbproject/Makefile-default.mk
+++ b/tests/unit/target_pic18.X/nbproject/Makefile-default.mk
@@ -97,42 +97,42 @@ ${OBJECTDIR}/pic18_main.p1: pic18_main.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/pic18_main.p1.d 
 	@${RM} ${OBJECTDIR}/pic18_main.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/pic18_main.p1 pic18_main.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/pic18_main.p1 pic18_main.c 
 	@${FIXDEPS} ${OBJECTDIR}/pic18_main.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1: ../can_buffering_layer.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/1472" 
 	@${RM} ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1 ../can_buffering_layer.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1 ../can_buffering_layer.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/1472/build_can_message.p1: ../build_can_message.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/1472" 
 	@${RM} ${OBJECTDIR}/_ext/1472/build_can_message.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/1472/build_can_message.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/build_can_message.p1 ../build_can_message.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/build_can_message.p1 ../build_can_message.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/1472/build_can_message.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/1472/can_common_tests.p1: ../can_common_tests.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/1472" 
 	@${RM} ${OBJECTDIR}/_ext/1472/can_common_tests.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/1472/can_common_tests.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/can_common_tests.p1 ../can_common_tests.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/can_common_tests.p1 ../can_common_tests.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/1472/can_common_tests.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/2124829536/can_common.p1: ../../../can_common.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/2124829536" 
 	@${RM} ${OBJECTDIR}/_ext/2124829536/can_common.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/2124829536/can_common.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/2124829536/can_common.p1 ../../../can_common.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/2124829536/can_common.p1 ../../../can_common.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/2124829536/can_common.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1: ../../../util/can_rcv_buffer.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/32770385" 
 	@${RM} ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1 ../../../util/can_rcv_buffer.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1 ../../../util/can_rcv_buffer.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 else
@@ -140,42 +140,42 @@ ${OBJECTDIR}/pic18_main.p1: pic18_main.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/pic18_main.p1.d 
 	@${RM} ${OBJECTDIR}/pic18_main.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/pic18_main.p1 pic18_main.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/pic18_main.p1 pic18_main.c 
 	@${FIXDEPS} ${OBJECTDIR}/pic18_main.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1: ../can_buffering_layer.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/1472" 
 	@${RM} ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1 ../can_buffering_layer.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1 ../can_buffering_layer.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/1472/can_buffering_layer.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/1472/build_can_message.p1: ../build_can_message.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/1472" 
 	@${RM} ${OBJECTDIR}/_ext/1472/build_can_message.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/1472/build_can_message.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/build_can_message.p1 ../build_can_message.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/build_can_message.p1 ../build_can_message.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/1472/build_can_message.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/1472/can_common_tests.p1: ../can_common_tests.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/1472" 
 	@${RM} ${OBJECTDIR}/_ext/1472/can_common_tests.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/1472/can_common_tests.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/can_common_tests.p1 ../can_common_tests.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/1472/can_common_tests.p1 ../can_common_tests.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/1472/can_common_tests.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/2124829536/can_common.p1: ../../../can_common.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/2124829536" 
 	@${RM} ${OBJECTDIR}/_ext/2124829536/can_common.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/2124829536/can_common.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/2124829536/can_common.p1 ../../../can_common.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/2124829536/can_common.p1 ../../../can_common.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/2124829536/can_common.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1: ../../../util/can_rcv_buffer.c  nbproject/Makefile-${CND_CONF}.mk
 	@${MKDIR} "${OBJECTDIR}/_ext/32770385" 
 	@${RM} ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1.d 
 	@${RM} ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1 
-	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1 ../../../util/can_rcv_buffer.c 
+	${MP_CC} $(MP_EXTRA_CC_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -c  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits $(COMPARISON_BUILD)  -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     -o ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1 ../../../util/can_rcv_buffer.c 
 	@${FIXDEPS} ${OBJECTDIR}/_ext/32770385/can_rcv_buffer.p1.d $(SILENT) -rsi ${MP_CC_DIR}../  
 	
 endif
@@ -197,13 +197,13 @@ endif
 ifeq ($(TYPE_IMAGE), DEBUG_RUN)
 dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.${OUTPUT_SUFFIX}: ${OBJECTFILES}  nbproject/Makefile-${CND_CONF}.mk    
 	@${MKDIR} dist/${CND_CONF}/${IMAGE_TYPE} 
-	${MP_CC} $(MP_EXTRA_LD_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -Wl,-Map=dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.map  -D__DEBUG=1  -DXPRJ_default=$(CND_CONF)  -Wl,--defsym=__MPLAB_BUILD=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto        $(COMPARISON_BUILD) -Wl,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml -o dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}     
+	${MP_CC} $(MP_EXTRA_LD_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -Wl,-Map=dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.map  -D__DEBUG=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto        $(COMPARISON_BUILD) -Wl,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml -o dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -DXPRJ_default=$(CND_CONF) 
 	@${RM} dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.hex 
 	
 else
 dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.${OUTPUT_SUFFIX}: ${OBJECTFILES}  nbproject/Makefile-${CND_CONF}.mk   
 	@${MKDIR} dist/${CND_CONF}/${IMAGE_TYPE} 
-	${MP_CC} $(MP_EXTRA_LD_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -Wl,-Map=dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.map  -DXPRJ_default=$(CND_CONF)  -Wl,--defsym=__MPLAB_BUILD=1  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DNO_PRINTF -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits -std=c99 -gdwarf-3 -mstack=compiled:auto:auto:auto     $(COMPARISON_BUILD) -Wl,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml -o dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}     
+	${MP_CC} $(MP_EXTRA_LD_PRE) -mcpu=$(MP_PROCESSOR_OPTION) -Wl,-Map=dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.map  -fno-short-double -fno-short-float -memi=wordwrite -O0 -fasmfile -maddrqual=ignore -DBOARD_UNIQUE_ID=0x03 -xassembler-with-cpp -I"../" -I"../../../util" -I"../../../" -Wa,-a -DXPRJ_default=$(CND_CONF)  -msummary=-psect,-class,+mem,-hex,-file  -ginhx032 -Wl,--data-init -mno-keep-startup -mno-download -mdefault-config-bits -std=c90 -gdwarf-3 -mstack=compiled:auto:auto:auto     $(COMPARISON_BUILD) -Wl,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml -o dist/${CND_CONF}/${IMAGE_TYPE}/target_pic18.X.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -DXPRJ_default=$(CND_CONF) 
 	
 endif
 

--- a/tests/unit/target_pic18.X/nbproject/Makefile-genesis.properties
+++ b/tests/unit/target_pic18.X/nbproject/Makefile-genesis.properties
@@ -1,7 +1,7 @@
 #
-#Sat Mar 09 20:22:41 PST 2019
+#Sun Mar 10 15:24:52 PDT 2019
 default.languagetoolchain.dir=/Applications/microchip/xc8/v2.05/bin
-configurations-xml=2d488bce27d1b5c2fd33dbe4e33df970
+configurations-xml=d835f08cb9481ce79fe8f7c206bc7714
 com-microchip-mplab-nbide-embedded-makeproject-MakeProject.md5=3c333ba33c51ccc254bb69f65f4fff20
 default.languagetoolchain.version=2.05
 host.platform=mac

--- a/tests/unit/target_pic18.X/nbproject/Makefile-genesis.properties
+++ b/tests/unit/target_pic18.X/nbproject/Makefile-genesis.properties
@@ -1,9 +1,9 @@
 #
-#Fri Mar 01 21:48:55 EST 2019
-default.languagetoolchain.dir=/opt/microchip/xc8/v2.00/bin
-configurations-xml=d1deedf2147f6d8796885d02a2d32ccb
-com-microchip-mplab-nbide-embedded-makeproject-MakeProject.md5=9d53b989b6ed2b6446aae58c2779ca87
-default.languagetoolchain.version=2.00
-host.platform=linux
+#Sat Mar 09 20:22:41 PST 2019
+default.languagetoolchain.dir=/Applications/microchip/xc8/v2.05/bin
+configurations-xml=2d488bce27d1b5c2fd33dbe4e33df970
+com-microchip-mplab-nbide-embedded-makeproject-MakeProject.md5=3c333ba33c51ccc254bb69f65f4fff20
+default.languagetoolchain.version=2.05
+host.platform=mac
 conf.ids=default
-default.com-microchip-mplab-nbide-toolchainXC8-XC8LanguageToolchain.md5=d0b8fdc2be6cb87257c6731763a65529
+default.com-microchip-mplab-nbide-toolchainXC8-XC8LanguageToolchain.md5=82aae3dc951968745b1174478554f96e

--- a/tests/unit/target_pic18.X/nbproject/Makefile-local-default.mk
+++ b/tests/unit/target_pic18.X/nbproject/Makefile-local-default.mk
@@ -14,23 +14,23 @@
 # You can invoke make with the values of the macros:
 # $ makeMP_CC="/opt/microchip/mplabc30/v3.30c/bin/pic30-gcc" ...  
 #
-PATH_TO_IDE_BIN=/opt/microchip/mplabx/v5.00/mplab_platform/platform/../mplab_ide/modules/../../bin/
+PATH_TO_IDE_BIN=/Applications/microchip/mplabx/v4.20/mplab_platform/platform/../mplab_ide/modules/../../bin/
 # Adding MPLAB X bin directory to path.
-PATH:=/opt/microchip/mplabx/v5.00/mplab_platform/platform/../mplab_ide/modules/../../bin/:$(PATH)
+PATH:=/Applications/microchip/mplabx/v4.20/mplab_platform/platform/../mplab_ide/modules/../../bin/:$(PATH)
 # Path to java used to run MPLAB X when this makefile was created
-MP_JAVA_PATH="/opt/microchip/mplabx/v5.00/sys/java/jre1.8.0_144/bin/"
+MP_JAVA_PATH="/Applications/microchip/mplabx/v4.20/sys/java/jre1.8.0_144.jre/Contents/Home/bin/"
 OS_CURRENT="$(shell uname -s)"
-MP_CC="/opt/microchip/xc8/v2.00/bin/xc8-cc"
+MP_CC="/Applications/microchip/xc8/v2.05/bin/xc8-cc"
 # MP_CPPC is not defined
 # MP_BC is not defined
-MP_AS="/opt/microchip/xc8/v2.00/bin/xc8-cc"
-MP_LD="/opt/microchip/xc8/v2.00/bin/xc8-cc"
-MP_AR="/opt/microchip/xc8/v2.00/bin/xc8-ar"
-DEP_GEN=${MP_JAVA_PATH}java -jar "/opt/microchip/mplabx/v5.00/mplab_platform/platform/../mplab_ide/modules/../../bin/extractobjectdependencies.jar"
-MP_CC_DIR="/opt/microchip/xc8/v2.00/bin"
+MP_AS="/Applications/microchip/xc8/v2.05/bin/xc8-cc"
+MP_LD="/Applications/microchip/xc8/v2.05/bin/xc8-cc"
+MP_AR="/Applications/microchip/xc8/v2.05/bin/xc8-ar"
+DEP_GEN=${MP_JAVA_PATH}java -jar "/Applications/microchip/mplabx/v4.20/mplab_platform/platform/../mplab_ide/modules/../../bin/extractobjectdependencies.jar"
+MP_CC_DIR="/Applications/microchip/xc8/v2.05/bin"
 # MP_CPPC_DIR is not defined
 # MP_BC_DIR is not defined
-MP_AS_DIR="/opt/microchip/xc8/v2.00/bin"
-MP_LD_DIR="/opt/microchip/xc8/v2.00/bin"
-MP_AR_DIR="/opt/microchip/xc8/v2.00/bin"
+MP_AS_DIR="/Applications/microchip/xc8/v2.05/bin"
+MP_LD_DIR="/Applications/microchip/xc8/v2.05/bin"
+MP_AR_DIR="/Applications/microchip/xc8/v2.05/bin"
 # MP_BC_DIR is not defined

--- a/tests/unit/target_pic18.X/nbproject/configurations.xml
+++ b/tests/unit/target_pic18.X/nbproject/configurations.xml
@@ -146,6 +146,7 @@
                   value="Press to browse for a specific firmware version"/>
         <property key="ToolFirmwareOption.UseLatestFirmware" value="true"/>
         <property key="debugoptions.useswbreakpoints" value="false"/>
+        <property key="firmware.download.all" value="false"/>
         <property key="hwtoolclock.frcindebug" value="false"/>
         <property key="memories.aux" value="false"/>
         <property key="memories.bootflash" value="true"/>

--- a/tests/unit/target_pic18.X/nbproject/configurations.xml
+++ b/tests/unit/target_pic18.X/nbproject/configurations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configurationDescriptor version="65">
+<configurationDescriptor version="62">
   <logicalFolder name="root" displayName="root" projectFiles="true">
     <logicalFolder name="HeaderFiles"
                    displayName="Header Files"
@@ -42,12 +42,9 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC8</languageToolchain>
-        <languageToolchainVersion>2.00</languageToolchainVersion>
-        <platform>2</platform>
+        <languageToolchainVersion>2.05</languageToolchainVersion>
+        <platform>4</platform>
       </toolsSet>
-      <packs>
-        <pack name="PIC18F-K_DFP" vendor="Microchip" version="0.1.33"/>
-      </packs>
       <compileType>
         <linkerTool>
           <linkerLibItems>
@@ -74,7 +71,7 @@
       </makeCustomizationType>
       <HI-TECH-COMP>
         <property key="asmlist" value="true"/>
-        <property key="define-macros" value="NO_PRINTF;BOARD_UNIQUE_ID=0x03"/>
+        <property key="define-macros" value="BOARD_UNIQUE_ID=0x03"/>
         <property key="disable-optimizations" value="false"/>
         <property key="extra-include-directories" value="../;../../../util;../../../"/>
         <property key="favor-optimization-for" value="-speed,+space"/>
@@ -122,7 +119,6 @@
         <property key="display-hex-usage" value="false"/>
         <property key="display-overall-usage" value="true"/>
         <property key="display-psect-usage" value="false"/>
-        <property key="extra-lib-directories" value=""/>
         <property key="fill-flash-options-addr" value=""/>
         <property key="fill-flash-options-const" value=""/>
         <property key="fill-flash-options-how" value="0"/>
@@ -132,7 +128,6 @@
         <property key="fill-flash-options-what" value="0"/>
         <property key="format-hex-file-for-download" value="false"/>
         <property key="initialize-data" value="true"/>
-        <property key="input-libraries" value="libm"/>
         <property key="keep-generated-startup.as" value="false"/>
         <property key="link-in-c-library" value="true"/>
         <property key="link-in-c-library-gcc" value=""/>
@@ -188,15 +183,13 @@
       <XC8-config-global>
         <property key="advanced-elf" value="true"/>
         <property key="gcc-opt-driver-new" value="true"/>
-        <property key="gcc-opt-std" value="-std=c99"/>
+        <property key="gcc-opt-std" value="-std=c90"/>
         <property key="gcc-output-file-format" value="dwarf-3"/>
-        <property key="omit-pack-options" value="false"/>
         <property key="output-file-format" value="-mcof,+elf"/>
         <property key="stack-size-high" value="auto"/>
         <property key="stack-size-low" value="auto"/>
         <property key="stack-size-main" value="auto"/>
         <property key="stack-type" value="compiled"/>
-        <property key="user-pack-device-support" value=""/>
       </XC8-config-global>
     </conf>
   </confs>

--- a/tests/unit/target_pic18.X/pic18_main.c
+++ b/tests/unit/target_pic18.X/pic18_main.c
@@ -60,18 +60,25 @@
 #include "can_common_tests.h"
 #include "can_buffering_layer.h"
 
-// These LEDs are the ones that exist on radio board. So run these tests
-// on radio borad
+// These LEDs are the ones that exist on picdev. So run these tests
+// on radio picdev
 static void leds_init()
 {
     // set all three leds as outputs
-    LATC1 = 1;
-    TRISC1 = 0;
-    LATA4 = 1;
-    TRISA4 = 0;
-    LATA5 = 1;
-    TRISA5 = 0;
+    LATB4 = 1;
+    TRISB4 = 0;
+    LATB3 = 1;
+    TRISB3 = 0;
+    LATB2 = 1;
+    TRISB2 = 0;
 }
+
+#define LED1_ON() (LATB4 = 0)
+#define LED1_OFF() (LATB4 = 1)
+#define LED2_ON() (LATB3 = 0)
+#define LED2_OFF() (LATB3 = 1)
+#define LED3_ON() (LATB2 = 0)
+#define LED3_OFF() (LATB2 = 1)
 
 int main()
 {
@@ -80,7 +87,7 @@ int main()
 
     bool all_tests_passed = true;
     // while we're running the tests, turn LED 2 on
-    LATA4 = 0;
+    LED2_ON();
 
     if (!test_build_can_message()) {
         all_tests_passed = false;
@@ -96,13 +103,13 @@ int main()
     }
 
     // end of the tests, turn LED 2 off
-    LATA4 = 1;
+    LED2_OFF();
     if (all_tests_passed) {
         // the success LED is LED 3
-        LATA5 = 0;
+        LED3_ON();
     } else {
         // the failure LED is LED 1
-        LATC1 = 0;
+        LED1_ON();
     }
 
     // loop forever


### PR DESCRIPTION
Replace the generic build_can_msg function with a set of more granular
functions for each message type. This is because the current
implementation of build_can_message exposes too much of the internal
message format (data that is passed to it must already be correctly
formatted). Its original intent was to be used inside wrapper functions.
However, it is a bit too rigid to be used effectively as such, and there
is very little that is common between all message types.

The unit tests have been updated to use the new functions.