### PR TITLE
Create DEBUG_RADIO_CMD CAN message type

### DIFF
--- a/can_common.c
+++ b/can_common.c
@@ -374,3 +374,12 @@ const char *build_printf_can_message(const char *string, can_msg_t *output)
     output->data_len = i;
     return string;
 }
+
+const char *build_radio_cmd_can_message(const char *string, can_msg_t *output)
+{
+    // let build_printf_can_message do all the heavy lifting
+    string = build_printf_can_message(string, output);
+    // then just set SID, since that's the only difference in message type
+    output->sid = (MSG_DEBUG_RADIO_CMD | BOARD_UNIQUE_ID);
+    return string;
+}

--- a/can_common.h
+++ b/can_common.h
@@ -172,7 +172,7 @@ bool get_analog_data(const can_msg_t *msg,
 can_debug_level_t message_debug_level(const can_msg_t *msg);
 
 /*
- * These commands build CAN messages who's data bytes are the ASCII characters
+ * These commands build CAN messages whose data bytes are the ASCII characters
  * from string. The functions return a pointer to the first character in string
  * which wasn't copied into output.
  *

--- a/can_common.h
+++ b/can_common.h
@@ -172,9 +172,23 @@ bool get_analog_data(const can_msg_t *msg,
 can_debug_level_t message_debug_level(const can_msg_t *msg);
 
 /*
- *  TODO, add comments. The code is written, comments are still needed
+ * These commands build CAN messages who's data bytes are the ASCII characters
+ * from string. The functions return a pointer to the first character in string
+ * which wasn't copied into output.
+ *
+ * So if you pass the function string="a long string", "a long s" will be put into
+ * output, and "tring" will be returned. You can tell if all of the string was
+ * copied into output if the return value points to a '\0'
+ *
+ * You can build and send an arbitrary length string with the following C code:
+ *   const char* string = "arbitrarily long string";
+ *   can_msg_t output;
+ *   while (*string) {
+ *       string = build_printf_can_message(string, &output);
+ *       can_send(&output);
+ *   }
  */
 const char *build_printf_can_message(const char *string, can_msg_t *output);
-
+const char *build_radio_cmd_can_message(const char *string, can_msg_t *output);
 
 #endif // compile guard

--- a/message_types.h
+++ b/message_types.h
@@ -21,6 +21,7 @@
 
 #define MSG_DEBUG_MSG             0x180
 #define MSG_DEBUG_PRINTF          0x1E0
+#define MSG_DEBUG_RADIO_CMD       0x200
 
 #define MSG_VENT_VALVE_STATUS     0x460
 #define MSG_INJ_VALVE_STATUS      0x4C0
@@ -56,6 +57,7 @@
  * INJ_VALVE_CMD:   TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    INJ_VALVE_STATE         None            None            None            None
  * DEBUG_MSG:       TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEBUG_LEVEL | LINUM_H   LINUM_L         MESSAGE_DEFINED MESSAGE_DEFINED MESSAGE_DEFINED
  * DEBUG_PRINTF:    ASCII       ASCII        ASCII          ASCII                   ASCII           ASCII           ASCII           ASCII
+ * DEBUG_RADIO_CMD: ASCII       ASCII        ASCII          ASCII                   ASCII           ASCII           ASCII           ASCII
  * VENT_VALVE_STAT: TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    VENT_VALVE_STATE        CMD_VALVE_STATE None            None            None
  * INJ_VALVE_STAT:  TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    INJ_VALVE_STATE         CMD_VALVE_STATE None            None            None
  * BOARD_STAT:      TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ERROR_CODE              BOARD_DEFINED   BOARD_DEFINED   BOARD_DEFINED   BOARD_DEFINED

--- a/tests/unit/can_common_tests.c
+++ b/tests/unit/can_common_tests.c
@@ -150,6 +150,93 @@ static bool test_debug_printf(void)
     return ret;
 }
 
+static bool test_debug_radio_cmd(void)
+{
+    // test that debug radio works, and can write out "does this work lol?" (which should take 3 messages to write)
+    can_msg_t output;
+    const char *message = "does this work lol?";
+    bool ret = true;
+
+    // this call should put "does thi" in output, and should set message to "s work lol?"
+    message = build_radio_cmd_can_message(message, &output);
+    if (output.data_len != 8) {
+        REPORT_FAIL("First call to build_radio_cmd_can_message didn't set data_len properly");
+        ret = false;
+    } else if (output.data[0] != 'd' ||
+               output.data[1] != 'o' ||
+               output.data[2] != 'e' ||
+               output.data[3] != 's' ||
+               output.data[4] != ' ' ||
+               output.data[5] != 't' ||
+               output.data[6] != 'h' ||
+               output.data[7] != 'i') {
+        REPORT_FAIL("First call to build_radio_cmd_can_message didn't set data properly");
+        ret = false;
+    } else if (strcmp(message, "s work lol?")) {
+        REPORT_FAIL("First call to build_radio_cmd_can_message didn't set message properly");
+        ret = false;
+    } else if (output.sid != 0x203) {
+        REPORT_FAIL("First call to build_radio_cmd_can_message didn't set sid properly");
+        ret = false;
+    }
+
+    // this call should put "s work l" in output, and should set message to "ol?"
+    message = build_radio_cmd_can_message(message, &output);
+    if (output.data_len != 8) {
+        REPORT_FAIL("Second call to build_radio_cmd_can_message didn't set data_len properly");
+        ret = false;
+    } else if (output.data[0] != 's' ||
+               output.data[1] != ' ' ||
+               output.data[2] != 'w' ||
+               output.data[3] != 'o' ||
+               output.data[4] != 'r' ||
+               output.data[5] != 'k' ||
+               output.data[6] != ' ' ||
+               output.data[7] != 'l') {
+        REPORT_FAIL("Second call to build_radio_cmd_can_message didn't set data properly");
+        ret = false;
+    } else if (strcmp(message, "ol?")) {
+        REPORT_FAIL("Second call to build_radio_cmd_can_message didn't set message properly");
+        ret = false;
+    } else if (output.sid != 0x203) {
+        REPORT_FAIL("Second call to build_radio_cmd_can_message didn't set sid properly");
+        ret = false;
+    }
+
+    // this call should put "ol?" in output, and should set message to '\0'
+    message = build_radio_cmd_can_message(message, &output);
+    if (output.data_len != 3) {
+        REPORT_FAIL("Third call to build_radio_cmd_can_message didn't set data_len properly");
+        ret = false;
+    } else if (output.data[0] != 'o' ||
+               output.data[1] != 'l' ||
+               output.data[2] != '?') {
+        REPORT_FAIL("Third call to build_radio_cmd_can_message didn't set data properly");
+        ret = false;
+    } else if (*message != '\0') {
+        REPORT_FAIL("Third call to build_radio_cmd_can_message didn't set message properly");
+        ret = false;
+    } else if (output.sid != 0x203) {
+        REPORT_FAIL("Third call to build_radio_cmd_can_message didn't set sid properly");
+        ret = false;
+    }
+
+    // this call should put nothing in output, and shouldn't change message
+    message = build_radio_cmd_can_message(message, &output);
+    if (output.data_len != 0) {
+        REPORT_FAIL("Fourth call to build_radio_cmd_can_message didn't set data_len properly");
+        ret = false;
+    } else if (*message != '\0') {
+        REPORT_FAIL("Fourth call to build_radio_cmd_can_message didn't set message properly");
+        ret = false;
+    } else if (output.sid != 0x203) {
+        REPORT_FAIL("Fourth call to build_radio_cmd_can_message didn't set sid properly");
+        ret = false;
+    }
+
+    return ret;
+}
+
 bool test_debug_macro(void)
 {
     // run the debug macro, and check that it puts in the line number
@@ -200,6 +287,10 @@ bool test_can_common_functions(void)
     }
     if (!test_debug_printf()) {
         REPORT_FAIL("Error, test_debug_printf returned false");
+        ret = false;
+    }
+    if (!test_debug_radio_cmd()) {
+        REPORT_FAIL("Error, test_debug_radio_cmd returned false");
         ret = false;
     }
     if (!test_debug_macro()) {


### PR DESCRIPTION
It's effectively the same as a debug printf CAN message, but whenever
radio board receives one of these messages, it should handle each ASCII
byte of data as though it had received it from the XBEE.

The purpose of having such a CAN message is to be able to test/debug the
whole system without having RLCS set up. Radio board will be receiving
radio traffic from RLCS, so if we want to test how it handles that
traffic without using RLCS, we need to spoof radio commands, prefereably
from the USB debug board.