### PR TITLE
Added `can_send_rdy()` functions for the MCP2515 and DSPIC

### DIFF
--- a/dspic33epxxxgp50x/dspic33epxxxgp50x_can.c
+++ b/dspic33epxxxgp50x/dspic33epxxxgp50x_can.c
@@ -110,6 +110,11 @@ void can_send(const can_msg_t* message, uint8_t priority) {
     C1TR01CONbits.TXREQ0 = 1;
 }
 
+// Returns true if a message is ready to be sent
+bool can_send_rdy(void) {
+    return C1TR01CONbits.TXREQ0 == 0;
+}
+
 // Interrupt that runs whenever IFS2::C1IF is set
 void __attribute__((__interrupt__, no_auto_psv)) _C1Interrupt(void) {
     // a transmit successfully finished, we abort the message so it

--- a/dspic33epxxxgp50x/dspic33epxxxgp50x_can.c
+++ b/dspic33epxxxgp50x/dspic33epxxxgp50x_can.c
@@ -83,7 +83,7 @@ void init_can(const can_timing_t *timing,
 // Priority must be a 2 bit number defining how high the priority of
 // this message is vs the other ones queued to be sent. 0 is lowest
 // priority, 3 is highest
-void can_send(const can_msg_t* message, uint8_t priority) {
+void can_send(const can_msg_t* message) {
     // put the SID in buffer 0 of the DMA buffers
     can_msg_buf[0][0] = (message->sid << 2);
 

--- a/dspic33epxxxgp50x/dspic33epxxxgp50x_can.c
+++ b/dspic33epxxxgp50x/dspic33epxxxgp50x_can.c
@@ -102,10 +102,8 @@ void can_send(const can_msg_t* message, uint8_t priority) {
     can_msg_buf[0][5] = ((message->data[5] << 8) | message->data[4]);
     can_msg_buf[0][6] = ((message->data[7] << 8) | message->data[6]);
 
-    // set priority. There's 0 point in doing this until we allow
-    // multiple transmit buffers, but hey, might as well make the API
-    // stable across different PICs.
-    C1TR01CONbits.TX0PRI = priority;
+    // the message priority is always 3 (the highest)
+    C1TR01CONbits.TX0PRI = 3;
 
     C1TR01CONbits.TXREQ0 = 1;
 }

--- a/dspic33epxxxgp50x/dspic33epxxxgp50x_can.h
+++ b/dspic33epxxxgp50x/dspic33epxxxgp50x_can.h
@@ -21,4 +21,7 @@ void init_can(const can_timing_t *timing,
 // priority
 void can_send(const can_msg_t* message, uint8_t priority);
 
+// returns true if the CAN module is ready to send a message
+bool can_send_rdy(void);
+
 #endif // compile guard

--- a/dspic33epxxxgp50x/dspic33epxxxgp50x_can.h
+++ b/dspic33epxxxgp50x/dspic33epxxxgp50x_can.h
@@ -19,7 +19,7 @@ void init_can(const can_timing_t *timing,
 
 // send a CAN message. Priority is 3 or less, higher means higher
 // priority
-void can_send(const can_msg_t* message, uint8_t priority);
+void can_send(const can_msg_t* message);
 
 // returns true if the CAN module is ready to send a message
 bool can_send_rdy(void);

--- a/mcp2515/mcp_2515.c
+++ b/mcp2515/mcp_2515.c
@@ -102,6 +102,10 @@ void mcp_can_send(can_msg_t *msg) {
     mcp_write_reg(TXB0CTRL, 1 << 3);            // set txreq
 }
 
+bool mcp_can_send_rdy(void) {
+    return mcp_read_reg(TXB0CTRL) & 0b00001000 == 0;
+}
+
 bool mcp_can_receive(can_msg_t *msg) {
     uint8_t set = mcp_read_reg(CANINTF);
     if (set & 0b1) {

--- a/mcp2515/mcp_2515.h
+++ b/mcp2515/mcp_2515.h
@@ -8,6 +8,7 @@ void mcp_can_init(can_timing_t *can_params,
                   void (*spi_write_fcn)(uint8_t data),
                   void (*cs_drive_fcn)(uint8_t state));
 void mcp_can_send(can_msg_t *msg);
+bool mcp_can_send_rdy(void);
 bool mcp_can_receive(can_msg_t *msg);
 
 // register addresses

--- a/tests/dspic33ep256gp502.X/main.c
+++ b/tests/dspic33ep256gp502.X/main.c
@@ -94,10 +94,10 @@ int main() {
 
     // send 1 then the other forever
     while(1) {
-        can_send(&led1, 0);
+        can_send(&led1);
         // this delay feels like 200ms maybe?
         __delay32(1000000);
-        can_send(&led2, 0);
+        can_send(&led2);
         __delay32(1000000);
     }
 


### PR DESCRIPTION
Note: the MCP2515's corresponding function is called `mcp_can_send_rdy()` (and _not_ `can_send_rdy()`), in the same format as the MCP2515's other functions.

In addition, the priority argument was removed from the DSPIC's `can_send()` function, and the message priority was hardcoded to be the highest possible.