### PR TITLE
Increase gps coordinate precision

### DIFF
--- a/can.h
+++ b/can.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define CANLIB_VERSION            "v0.2.2"
+#define CANLIB_VERSION            "v0.3.0"
 #define CANLIB_BIT_TIME_US        24
 
 // Timing parameters

--- a/can_common.c
+++ b/can_common.c
@@ -218,7 +218,7 @@ bool build_gps_time_msg(uint32_t timestamp,
 bool build_gps_lat_msg(uint32_t timestamp,
                        uint8_t degrees,
                        uint8_t minutes,
-                       uint8_t dminutes,
+                       uint16_t dminutes,
                        uint8_t direction,
                        can_msg_t *output)
 {
@@ -229,10 +229,11 @@ bool build_gps_lat_msg(uint32_t timestamp,
 
     output->data[3] = degrees;
     output->data[4] = minutes;
-    output->data[5] = dminutes;
-    output->data[6] = direction;
+    output->data[5] = dminutes >> 8;
+    output->data[6] = dminutes & 0xF;
+    output->data[7] = direction;
 
-    output->data_len = 7;
+    output->data_len = 8;
 
     return true;
 }
@@ -240,7 +241,7 @@ bool build_gps_lat_msg(uint32_t timestamp,
 bool build_gps_lon_msg(uint32_t timestamp,
                        uint8_t degrees,
                        uint8_t minutes,
-                       uint8_t dminutes,
+                       uint16_t dminutes,
                        uint8_t direction,
                        can_msg_t *output)
 {
@@ -251,10 +252,11 @@ bool build_gps_lon_msg(uint32_t timestamp,
 
     output->data[3] = degrees;
     output->data[4] = minutes;
-    output->data[5] = dminutes;
-    output->data[6] = direction;
+    output->data[5] = dminutes >> 8;
+    output->data[6] = dminutes & 0xF;
+    output->data[7] = direction;
 
-    output->data_len = 7;
+    output->data_len = 8;
 
     return true;
 }
@@ -504,7 +506,7 @@ bool get_gps_time(const can_msg_t *msg,
 bool get_gps_lat(const can_msg_t *msg,
                  uint8_t *degrees,
                  uint8_t *minutes,
-                 uint8_t *dminutes,
+                 uint16_t *dminutes,
                  uint8_t *direction)
 {
     if (!msg) { return false; }
@@ -516,8 +518,8 @@ bool get_gps_lat(const can_msg_t *msg,
 
     *degrees = msg->data[3];
     *minutes = msg->data[4];
-    *dminutes = msg->data[5];
-    *direction = msg->data[6];
+    *dminutes = msg->data[5] << 8 | msg->data[6];
+    *direction = msg->data[7];
 
     return true;
 }
@@ -525,7 +527,7 @@ bool get_gps_lat(const can_msg_t *msg,
 bool get_gps_lon(const can_msg_t *msg,
                  uint8_t *degrees,
                  uint8_t *minutes,
-                 uint8_t *dminutes,
+                 uint16_t *dminutes,
                  uint8_t *direction)
 {
     if (!msg) { return false; }
@@ -537,8 +539,8 @@ bool get_gps_lon(const can_msg_t *msg,
 
     *degrees = msg->data[3];
     *minutes = msg->data[4];
-    *dminutes = msg->data[5];
-    *direction = msg->data[6];
+    *dminutes = msg->data[5] << 8 | msg->data[6];
+    *direction = msg->data[7];
 
     return true;
 }

--- a/can_common.c
+++ b/can_common.c
@@ -230,7 +230,7 @@ bool build_gps_lat_msg(uint32_t timestamp,
     output->data[3] = degrees;
     output->data[4] = minutes;
     output->data[5] = dminutes >> 8;
-    output->data[6] = dminutes & 0xF;
+    output->data[6] = dminutes & 0xFF;
     output->data[7] = direction;
 
     output->data_len = 8;
@@ -253,7 +253,7 @@ bool build_gps_lon_msg(uint32_t timestamp,
     output->data[3] = degrees;
     output->data[4] = minutes;
     output->data[5] = dminutes >> 8;
-    output->data[6] = dminutes & 0xF;
+    output->data[6] = dminutes & 0xFF;
     output->data[7] = direction;
 
     output->data_len = 8;

--- a/can_common.h
+++ b/can_common.h
@@ -128,7 +128,7 @@ bool build_gps_time_msg(uint32_t timestamp,
 bool build_gps_lat_msg(uint32_t timestamp,
                        uint8_t degrees,
                        uint8_t minutes,
-                       uint8_t dminutes,
+                       uint16_t dminutes,
                        uint8_t direction,
                        can_msg_t *output);
 
@@ -140,7 +140,7 @@ bool build_gps_lat_msg(uint32_t timestamp,
 bool build_gps_lon_msg(uint32_t timestamp,
                        uint8_t degrees,
                        uint8_t minutes,
-                       uint8_t dminutes,
+                       uint16_t dminutes,
                        uint8_t direction,
                        can_msg_t *output);
 
@@ -243,7 +243,7 @@ bool get_gps_time(const can_msg_t* msg,
 bool get_gps_lat(const can_msg_t* msg,
                  uint8_t *degrees,
                  uint8_t *minutes,
-                 uint8_t *dminutes,
+                 uint16_t *dminutes,
                  uint8_t *direction);
 
 /*
@@ -254,7 +254,7 @@ bool get_gps_lat(const can_msg_t* msg,
 bool get_gps_lon(const can_msg_t* msg,
                  uint8_t *degrees,
                  uint8_t *minutes,
-                 uint8_t *dminutes,
+                 uint16_t *dminutes,
                  uint8_t *direction);
 
 /*

--- a/message_types.h
+++ b/message_types.h
@@ -83,8 +83,8 @@
  * SENSOR_ANALOG:   TSTAMP_MS_M TSTAMP_MS_L  SENSOR_ID      VALUE_H                 VALUE_L         None            None            None
  *
  * GPS_TIMESTAMP:   TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    UTC_HOURS               UTC_MINUTES     UTC_SECONDS     UTC_DSECONDS    None
- * GPS_LAT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES         DMINUTES        N/S DIRECTION   None
- * GPS_LON:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES         DMINUTES        E/W DIRECTION   None
+ * GPS_LAT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES         DMINUTES_H      DIMNUTES_L      N/S DIRECTION
+ * GPS_LON:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES         DMINUTES_H      DIMNUTES_L      E/W DIRECTION
  * GPS_ALT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_H                   ALT_L           ALT_DEC         UNITS           None
  * GPS_INFO:        TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    NUM_SAT                 QUALITY         None            None            None
  *

--- a/tests/unit/build_can_message.c
+++ b/tests/unit/build_can_message.c
@@ -351,7 +351,7 @@ bool test_gps(void)
     // test lat/lon
     uint8_t degrees = 145;
     uint8_t minutes = 45;
-    uint8_t dminutes = 23;
+    uint16_t dminutes = 2300;
     uint8_t direction_ns = 'S';
     uint8_t direction_ew = 'E';
 
@@ -413,7 +413,8 @@ bool test_gps(void)
         ret = false;
     }
 
-    uint8_t degrees_, minutes_, dminutes_, direction_;
+    uint8_t degrees_, minutes_, direction_;
+    uint16_t dminutes_;
     timestamp_ = get_timestamp(&output);
     if (!get_gps_lat(&output, &degrees_, &minutes_, &dminutes_, &direction_)) {
         REPORT_FAIL("Error getting latitude data");


### PR DESCRIPTION
This gives decimals an extra byte for gps latitude and longitude.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/canlib/28)
<!-- Reviewable:end -->
