### PR TITLE
fixed namespace collision with cube ide

### DIFF
--- a/can.h
+++ b/can.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define CANLIB_VERSION            "v0.1.0"
+#define CANLIB_VERSION            "v0.1.1"
 #define CANLIB_BIT_TIME_US        24
 
 // Timing parameters

--- a/can_common.h
+++ b/can_common.h
@@ -11,11 +11,11 @@
  * numbers are more serious debug things
  */
 typedef enum {
-    NONE  = 0,
-    ERROR = 1,
-    WARN  = 2,
-    INFO  = 3,
-    DEBUG = 4
+    NONE      = 0,
+    ERROR     = 1,
+    WARN      = 2,
+    INFO      = 3,
+    DEBUGGING = 4
 } can_debug_level_t;
 
 /*
@@ -26,7 +26,7 @@ typedef enum {
  * the code later to see where the debug was issued from, and
  * hopefully find the cause of the problem
  */
-#define DEBUG(debug_macro_level, debug_macro_timestamp, debug_macro_output) \
+#define LOG_MSG(debug_macro_level, debug_macro_timestamp, debug_macro_output) \
     do {                                                                \
         uint8_t debug_macro_data[5] = {(debug_macro_level << 4) | ((__LINE__ >> 8) & 0xF), \
                                        __LINE__ & 0xFF,                 \

--- a/tests/unit/can_common_tests.c
+++ b/tests/unit/can_common_tests.c
@@ -56,7 +56,7 @@ static bool test_message_debug_level(void)
         REPORT_FAIL("fail on build_can_message when level is DEBUG");
         ret = false;
     }
-    if (DEBUG != message_debug_level(&output)) {
+    if (DEBUGGING != message_debug_level(&output)) {
         REPORT_FAIL("fail on message_debug_level when level is DEBUG");
         ret = false;
     }
@@ -243,7 +243,7 @@ bool test_debug_macro(void)
     // right
     can_msg_t output;
     int linum = __LINE__ + 1;
-    DEBUG(ERROR, 0, output);
+    LOG_MSG(ERROR, 0, output);
 
     bool ret = true;
 


### PR DESCRIPTION
The STM32CubeIDE takes `DEBUG` as a special preprocessing variable/macro so renaming fixed the build errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/canlib/29)
<!-- Reviewable:end -->
