### PR TITLE
Add 48MHz params to can_generate_timing_params

### DIFF
--- a/util/timing_util.c
+++ b/util/timing_util.c
@@ -8,6 +8,15 @@ bool can_generate_timing_params(uint32_t can_frequency, can_timing_t *timing)
 {
     // this function is designed to create a bit time of 24 microseconds
     switch (can_frequency) {
+        case 48000000:
+            timing->brp      = 47;
+            timing->sjw      =  3;
+            timing->btlmode  =  1;
+            timing->sam      =  0;
+            timing->seg1ph   =  4;
+            timing->prseg    =  0;
+            timing->seg2ph   =  4;
+            return true;
         case 32000000:
             timing->brp      = 31;
             timing->sjw      =  3;


### PR DESCRIPTION
I'm not 100% sure what each parameter means 😅, but I assume they'd be the same as all other frequencies as they seem to work.

Related: https://github.com/waterloo-rocketry/cansw_gps/pull/3#pullrequestreview-539699277

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/canlib/30)
<!-- Reviewable:end -->
