### PR TITLE
Check overflow bits from buffer 1 as well

### DIFF
--- a/pic18f26k83/pic18f26k83_can.c
+++ b/pic18f26k83/pic18f26k83_can.c
@@ -121,8 +121,9 @@ void can_handle_interrupt() {
     // if there was already a message in the receive buffer and we
     // received another message, just drop that message. Apparently
     // your code isn't fast enough.
-    if (COMSTATbits.RXB0OVFL) {
+    if (COMSTATbits.RXB0OVFL || COMSTATbits.RXB1OVFL) {
         COMSTATbits.RXB0OVFL = 0;
+        COMSTATbits.RXB1OVFL = 0;
     }
 
     // handle a received message by stuffing it into a can_message_t


### PR DESCRIPTION
This fixes boards potentially hanging if too many messages are received at once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/canlib/35)
<!-- Reviewable:end -->
