### PR TITLE
Rename valve to actuator everywhere

### DIFF
--- a/can.h
+++ b/can.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#define CANLIB_VERSION            "v0.6.0"
+#define CANLIB_VERSION            "v0.7.0"
 #define CANLIB_BIT_TIME_US        24
 
 // Timing parameters

--- a/can_common.h
+++ b/can_common.h
@@ -74,7 +74,7 @@ bool build_reset_msg(uint32_t timestamp,
  */
 bool build_actuator_cmd_msg(uint32_t timestamp,
                             enum ACTUATOR_ID actuator_id,
-                            enum VALVE_STATE valve_cmd,                  
+                            enum ACTUATOR_STATE actuator_cmd,
                             can_msg_t *output);
 
 /*
@@ -82,8 +82,8 @@ bool build_actuator_cmd_msg(uint32_t timestamp,
  */
 bool build_actuator_stat_msg(uint32_t timestamp,
                              enum ACTUATOR_ID actuator_id,
-                             enum VALVE_STATE valve_state,
-                             enum VALVE_STATE req_valve_state,
+                             enum ACTUATOR_STATE actuator_state,
+                             enum ACTUATOR_STATE req_actuator_state,
                              can_msg_t *output);
 
 /*
@@ -120,8 +120,8 @@ bool build_board_stat_msg(uint32_t timestamp,
  * Used to send 16-bit IMU data values. It is assumed that an array
  * of 3 values is sent (X, Y, and Z axes).
  */
-bool build_imu_data_msg(uint32_t timestamp,
-                        uint16_t message_type,  // acc, gyro, mag
+bool build_imu_data_msg(uint16_t message_type,  // acc, gyro, mag
+                        uint32_t timestamp,
                         uint16_t *imu_data,     // x, y, z
                         can_msg_t *output);
 
@@ -215,19 +215,24 @@ int get_general_cmd_type(const can_msg_t *msg);
  * Returns -1 if the provided message is not a reset command message.
  */
 int get_reset_board_id(const can_msg_t *msg);
-
  /*
-  * Returns the current valve state based on limit switch readings.
-  * Returns -1 if the provided message is not a vent/injector status message.
+  * Returns the actuator id from an actuator command or status message.
+  * Returns -1 if the provided message is not an actuator cmd/status.
   */
-int get_curr_valve_state(const can_msg_t *msg);
+int get_actuator_id(const can_msg_t *msg);
 
  /*
- * Returns the requested valve state from a valve command or
+  * Returns the current actuator state based on limit switch readings.
+  * Returns -1 if the provided message is not a actuator status message.
+  */
+int get_curr_actuator_state(const can_msg_t *msg);
+
+ /*
+ * Returns the requested actuator state from an actuator command or
  * status message. Returns -1 if the provided message is not
- * a valve cmd/status.
+ * an actuator cmd/status.
  */
-int get_req_valve_state(const can_msg_t *msg);
+int get_req_actuator_state(const can_msg_t *msg);
 
 /*
 * Gets the current arm state and which altimeter it is for.

--- a/can_common.h
+++ b/can_common.h
@@ -72,19 +72,19 @@ bool build_reset_msg(uint32_t timestamp,
 /*
  * Used to send injector and vent commands
  */
-bool build_valve_cmd_msg(uint32_t timestamp,
-                         enum VALVE_STATE valve_cmd,
-                         uint16_t message_type,  // vent or injector
-                         can_msg_t *output);
+bool build_actuator_cmd_msg(uint32_t timestamp,
+                            enum ACTUATOR_ID actuator_id,
+                            enum VALVE_STATE valve_cmd,                  
+                            can_msg_t *output);
 
 /*
  * Used to send injector/vent status: current and desired
  */
-bool build_valve_stat_msg(uint32_t timestamp,
-                          enum VALVE_STATE valve_state,
-                          enum VALVE_STATE req_valve_state,
-                          uint16_t message_type,    // vent or injector
-                          can_msg_t *output);
+bool build_actuator_stat_msg(uint32_t timestamp,
+                             enum ACTUATOR_ID actuator_id,
+                             enum VALVE_STATE valve_state,
+                             enum VALVE_STATE req_valve_state,
+                             can_msg_t *output);
 
 /*
 * Used to send altimeter arm commands
@@ -120,8 +120,8 @@ bool build_board_stat_msg(uint32_t timestamp,
  * Used to send 16-bit IMU data values. It is assumed that an array
  * of 3 values is sent (X, Y, and Z axes).
  */
-bool build_imu_data_msg(uint16_t message_type,  // acc, gyro, mag
-                        uint32_t timestamp,
+bool build_imu_data_msg(uint32_t timestamp,
+                        uint16_t message_type,  // acc, gyro, mag
                         uint16_t *imu_data,     // x, y, z
                         can_msg_t *output);
 

--- a/message_types.h
+++ b/message_types.h
@@ -72,38 +72,38 @@
 /*
  * General message type format (from spreadsheet):
  * (Version 0.7.0)
- *                  byte 0      byte 1       byte 2         byte 3                  byte 4              byte 5          byte 6          byte 7
- * GENERAL_CMD:     TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    COMMAND_TYPE            None                None            None            None
- * ACTUATOR_CMD:    TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ACTUATOR_ID             ACTUATOR_STATE      None            None            None
- * ALT_ARM_CMD:     TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_ARM_STATE & #       None                None            None            None
- * RESET_CMD:       TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    BOARD_ID                None                None            None            None
+ *                  byte 0      byte 1      byte 2      byte 3                byte 4         byte 5             byte 6          byte 7
+ * GENERAL_CMD:     TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L COMMAND_TYPE          None           None               None            None
+ * ACTUATOR_CMD:    TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ACTUATOR_ID           ACTUATOR_STATE None               None            None
+ * ALT_ARM_CMD:     TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ALT_ARM_STATE & #     None           None               None            None
+ * RESET_CMD:       TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L BOARD_ID              None           None               None            None
  *
- * DEBUG_MSG:       TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEBUG_LEVEL | LINUM_H   LINUM_L             MESSAGE_DEFINED MESSAGE_DEFINED MESSAGE_DEFINED
- * DEBUG_PRINTF:    ASCII       ASCII        ASCII          ASCII                   ASCII               ASCII           ASCII           ASCII
- * DEBUG_RADIO_CMD: ASCII       ASCII        ASCII          ASCII                   ASCII               ASCII           ASCII           ASCII
+ * DEBUG_MSG:       TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L DEBUG_LEVEL | LINUM_H LINUM_L        MESSAGE_DEFINED    MESSAGE_DEFINED MESSAGE_DEFINED
+ * DEBUG_PRINTF:    ASCII       ASCII       ASCII       ASCII                 ASCII          ASCII              ASCII           ASCII
+ * DEBUG_RADIO_CMD: ASCII       ASCII       ASCII       ASCII                 ASCII          ASCII              ASCII           ASCII
  *
- * ACTUATOR_STAT:   TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ACTUATOR_STATE          CMD_VALVE_STATE     None            None            None
- * ALT_ARM_STAT:    TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_ARM_STATE & #       V_DROGUE_H          V_DROGUE_L      V_MAIN_H        V_MAIN_L
- * BOARD_STAT:      TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ERROR_CODE              BOARD_DEFINED       BOARD_DEFINED   BOARD_DEFINED   BOARD_DEFINED
+ * ACTUATOR_STAT:   TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ACTUATOR_ID           ACTUATOR_STATE REQ_ACTUATOR_STATE None            None
+ * ALT_ARM_STAT:    TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ALT_ARM_STATE & #     V_DROGUE_H     V_DROGUE_L         V_MAIN_H        V_MAIN_L
+ * BOARD_STAT:      TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ERROR_CODE            BOARD_DEFINED  BOARD_DEFINED      BOARD_DEFINED   BOARD_DEFINED
  *
- * SENSOR_ALTITUDE: TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALTITUDE_H              ALTITUDE_MH         ALTITUDE_ML     ALTITUDE_L      None
- * SENSOR_ACC:      TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H           VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
- * SENSOR_GYRO:     TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H           VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
- * SENSOR_MAG:      TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H           VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
- * SENSOR_ANALOG:   TSTAMP_MS_M TSTAMP_MS_L  SENSOR_ID      VALUE_H                 VALUE_L             None            None            None
+ * SENSOR_ALTITUDE: TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ALTITUDE_H            ALTITUDE_MH    ALTITUDE_ML        ALTITUDE_L      None
+ * SENSOR_ACC:      TSTAMP_MS_M TSTAMP_MS_L VALUE_X_H   VALUE_X_L             VALUE_Y_H      VALUE_Y_L          VALUE_Z_H       VALUE_Z_L
+ * SENSOR_GYRO:     TSTAMP_MS_M TSTAMP_MS_L VALUE_X_H   VALUE_X_L             VALUE_Y_H      VALUE_Y_L          VALUE_Z_H       VALUE_Z_L
+ * SENSOR_MAG:      TSTAMP_MS_M TSTAMP_MS_L VALUE_X_H   VALUE_X_L             VALUE_Y_H      VALUE_Y_L          VALUE_Z_H       VALUE_Z_L
+ * SENSOR_ANALOG:   TSTAMP_MS_M TSTAMP_MS_L SENSOR_ID   VALUE_H               VALUE_L        None               None            None
  *
- * GPS_TIMESTAMP:   TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    UTC_HOURS               UTC_MINUTES         UTC_SECONDS     UTC_DSECONDS    None
- * GPS_LAT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES             DMINUTES_H      DIMNUTES_L      N/S DIRECTION
- * GPS_LON:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES             DMINUTES_H      DIMNUTES_L      E/W DIRECTION
- * GPS_ALT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_H                   ALT_L               ALT_DEC         UNITS           None
- * GPS_INFO:        TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    NUM_SAT                 QUALITY             None            None            None
+ * GPS_TIMESTAMP:   TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L UTC_HOURS             UTC_MINUTES    UTC_SECONDS        UTC_DSECONDS    None
+ * GPS_LAT:         TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L DEGREES               MINUTES        DMINUTES_H         DIMNUTES_L      N/S DIRECTION
+ * GPS_LON:         TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L DEGREES               MINUTES        DMINUTES_H         DIMNUTES_L      E/W DIRECTION
+ * GPS_ALT:         TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ALT_H                 ALT_L          ALT_DEC            UNITS           None
+ * GPS_INFO:        TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L NUM_SAT               QUALITY        None               None            None
  *
- * FILL_LVL:        TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    FILL_LEVEL              DIRECTION           None            None            None
+ * FILL_LVL:        TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L FILL_LEVEL            DIRECTION      None               None            None
  *
- * RADI_VALUE:      TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    RADI_BOARD              RADI_HIGH           RADI_LOW        None            None
+ * RADI_VALUE:      TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L RADI_BOARD            RADI_HIGH      RADI_LOW           None            None
  *
- * LEDS_ON:         None        None         None           None                    None                None            None            None
- * LEDS_OFF:        None        None         None           None                    None                None            None            None
+ * LEDS_ON:         None        None        None        None                  None           None               None            None
+ * LEDS_OFF:        None        None        None        None                  None           None               None            None
  *
  * This file defines the format of the various CAN message types (defined in
  * message_types.h). There is no unified message format; the format of each message
@@ -120,12 +120,12 @@ enum GEN_CMD {
     BUS_DOWN_WARNING = 0,
 };
 
-// VALVE_CMD/STATUS STATES
-enum VALVE_STATE {
-    VALVE_OPEN = 0,
-    VALVE_CLOSED,
-    VALVE_UNK,
-    VALVE_ILLEGAL,
+// ACTUATOR_CMD/STATUS STATES
+enum ACTUATOR_STATE {
+    ACTUATOR_OPEN = 0,
+    ACTUATOR_CLOSED,
+    ACTUATOR_UNK,
+    ACTUATOR_ILLEGAL,
 };
 
 // ARM_CMD/STATUS STATES
@@ -151,7 +151,7 @@ enum BOARD_STATUS {
     E_MISSING_CRITICAL_BOARD,   // board_id         x                   x                   x
     E_RADIO_SIGNAL_LOST,        // time_s_high      time_s_low          x                   x
 
-    E_VALVE_STATE,              // expected_state   valve_state         x                   x
+    E_ACTUATOR_STATE,           // expected_state   actuator_state      x                   x
     E_CANNOT_INIT_DACS,         // x                x                   x                   x
     E_VENT_POT_RANGE,           // lim_upper (mV)   lim_lower (mV)      pot (mV)            x
 
@@ -190,7 +190,8 @@ enum FILL_DIRECTION {
 };
 
 enum ACTUATOR_ID {
-    VENT_VALVE = 0,
+    ACTUATOR_VENT_VALVE = 0,
+    ACTUATOR_INJECTOR_VALVE,
 };
 
 #endif // compile guard

--- a/message_types.h
+++ b/message_types.h
@@ -192,6 +192,7 @@ enum FILL_DIRECTION {
 enum ACTUATOR_ID {
     ACTUATOR_VENT_VALVE = 0,
     ACTUATOR_INJECTOR_VALVE,
+    MAMA_BOARD_ACTIVATE,
 };
 
 #endif // compile guard

--- a/message_types.h
+++ b/message_types.h
@@ -16,8 +16,7 @@
  */
 
 #define MSG_GENERAL_CMD           0x060
-#define MSG_VENT_VALVE_CMD        0x0C0
-#define MSG_INJ_VALVE_CMD         0x120
+#define MSG_ACTUATOR_CMD          0x0C0
 #define MSG_ALT_ARM_CMD           0x140
 #define MSG_RESET_CMD             0x160
 
@@ -26,8 +25,7 @@
 #define MSG_DEBUG_RADIO_CMD       0x200
 
 #define MSG_ALT_ARM_STATUS        0x440
-#define MSG_VENT_VALVE_STATUS     0x460
-#define MSG_INJ_VALVE_STATUS      0x4C0
+#define MSG_ACTUATOR_STATUS       0x460
 #define MSG_GENERAL_BOARD_STATUS  0x520
 
 #define MSG_SENSOR_ALTITUDE       0x560
@@ -73,41 +71,39 @@
 
 /*
  * General message type format (from spreadsheet):
- * (Version 0.6.0)
- *                  byte 0      byte 1       byte 2         byte 3                  byte 4          byte 5          byte 6          byte 7
- * GENERAL_CMD:     TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    COMMAND_TYPE            None            None            None            None
- * VENT_VALVE_CMD:  TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    VENT_VALVE_STATE        None            None            None            None
- * INJ_VALVE_CMD:   TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    INJ_VALVE_STATE         None            None            None            None
- * ALT_ARM_CMD:     TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_ARM_STATE & #       None            None            None            None
- * RESET_CMD:       TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    BOARD_ID                None            None            None            None
+ * (Version 0.7.0)
+ *                  byte 0      byte 1       byte 2         byte 3                  byte 4              byte 5          byte 6          byte 7
+ * GENERAL_CMD:     TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    COMMAND_TYPE            None                None            None            None
+ * ACTUATOR_CMD:    TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ACTUATOR_ID             ACTUATOR_STATE      None            None            None
+ * ALT_ARM_CMD:     TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_ARM_STATE & #       None                None            None            None
+ * RESET_CMD:       TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    BOARD_ID                None                None            None            None
  *
- * DEBUG_MSG:       TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEBUG_LEVEL | LINUM_H   LINUM_L         MESSAGE_DEFINED MESSAGE_DEFINED MESSAGE_DEFINED
- * DEBUG_PRINTF:    ASCII       ASCII        ASCII          ASCII                   ASCII           ASCII           ASCII           ASCII
- * DEBUG_RADIO_CMD: ASCII       ASCII        ASCII          ASCII                   ASCII           ASCII           ASCII           ASCII
+ * DEBUG_MSG:       TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEBUG_LEVEL | LINUM_H   LINUM_L             MESSAGE_DEFINED MESSAGE_DEFINED MESSAGE_DEFINED
+ * DEBUG_PRINTF:    ASCII       ASCII        ASCII          ASCII                   ASCII               ASCII           ASCII           ASCII
+ * DEBUG_RADIO_CMD: ASCII       ASCII        ASCII          ASCII                   ASCII               ASCII           ASCII           ASCII
  *
- * VENT_VALVE_STAT: TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    VENT_VALVE_STATE        CMD_VALVE_STATE None            None            None
- * INJ_VALVE_STAT:  TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    INJ_VALVE_STATE         CMD_VALVE_STATE None            None            None
- * ALT_ARM_STAT:    TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_ARM_STATE & #       V_DROGUE_H      V_DROGUE_L      V_MAIN_H        V_MAIN_L
- * BOARD_STAT:      TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ERROR_CODE              BOARD_DEFINED   BOARD_DEFINED   BOARD_DEFINED   BOARD_DEFINED
+ * ACTUATOR_STAT:   TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ACTUATOR_STATE          CMD_VALVE_STATE     None            None            None
+ * ALT_ARM_STAT:    TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_ARM_STATE & #       V_DROGUE_H          V_DROGUE_L      V_MAIN_H        V_MAIN_L
+ * BOARD_STAT:      TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ERROR_CODE              BOARD_DEFINED       BOARD_DEFINED   BOARD_DEFINED   BOARD_DEFINED
  *
- * SENSOR_ALTITUDE: TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALTITUDE_H              ALTITUDE_MH     ALTITUDE_ML     ALTITUDE_L      None
- * SENSOR_ACC:      TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H       VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
- * SENSOR_GYRO:     TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H       VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
- * SENSOR_MAG:      TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H       VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
- * SENSOR_ANALOG:   TSTAMP_MS_M TSTAMP_MS_L  SENSOR_ID      VALUE_H                 VALUE_L         None            None            None
+ * SENSOR_ALTITUDE: TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALTITUDE_H              ALTITUDE_MH         ALTITUDE_ML     ALTITUDE_L      None
+ * SENSOR_ACC:      TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H           VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
+ * SENSOR_GYRO:     TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H           VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
+ * SENSOR_MAG:      TSTAMP_MS_M TSTAMP_MS_L  VALUE_X_H      VALUE_X_L               VALUE_Y_H           VALUE_Y_L       VALUE_Z_H       VALUE_Z_L
+ * SENSOR_ANALOG:   TSTAMP_MS_M TSTAMP_MS_L  SENSOR_ID      VALUE_H                 VALUE_L             None            None            None
  *
- * GPS_TIMESTAMP:   TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    UTC_HOURS               UTC_MINUTES     UTC_SECONDS     UTC_DSECONDS    None
- * GPS_LAT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES         DMINUTES_H      DIMNUTES_L      N/S DIRECTION
- * GPS_LON:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES         DMINUTES_H      DIMNUTES_L      E/W DIRECTION
- * GPS_ALT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_H                   ALT_L           ALT_DEC         UNITS           None
- * GPS_INFO:        TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    NUM_SAT                 QUALITY         None            None            None
+ * GPS_TIMESTAMP:   TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    UTC_HOURS               UTC_MINUTES         UTC_SECONDS     UTC_DSECONDS    None
+ * GPS_LAT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES             DMINUTES_H      DIMNUTES_L      N/S DIRECTION
+ * GPS_LON:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    DEGREES                 MINUTES             DMINUTES_H      DIMNUTES_L      E/W DIRECTION
+ * GPS_ALT:         TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    ALT_H                   ALT_L               ALT_DEC         UNITS           None
+ * GPS_INFO:        TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    NUM_SAT                 QUALITY             None            None            None
  *
- * FILL_LVL:        TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    FILL_LEVEL              DIRECTION       None            None            None
- * 
- * RADI_VALUE:      TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    RADI_BOARD              RADI_HIGH       RADI_LOW        None            None
- * 
- * LEDS_ON:         None        None         None           None                    None            None            None            None
- * LEDS_OFF:        None        None         None           None                    None            None            None            None
+ * FILL_LVL:        TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    FILL_LEVEL              DIRECTION           None            None            None
+ *
+ * RADI_VALUE:      TSTAMP_MS_H TSTAMP_MS_M  TSTAMP_MS_L    RADI_BOARD              RADI_HIGH           RADI_LOW        None            None
+ *
+ * LEDS_ON:         None        None         None           None                    None                None            None            None
+ * LEDS_OFF:        None        None         None           None                    None                None            None            None
  *
  * This file defines the format of the various CAN message types (defined in
  * message_types.h). There is no unified message format; the format of each message
@@ -193,5 +189,8 @@ enum FILL_DIRECTION {
     EMPTYING,
 };
 
+enum ACTUATOR_ID {
+    VENT_VALVE = 0,
+};
 
 #endif // compile guard

--- a/tests/unit/build_can_message.c
+++ b/tests/unit/build_can_message.c
@@ -109,7 +109,7 @@ static bool test_reset_command(void)
     return ret;
 }
 
-static bool test_valve_cmd(void)
+static bool test_actuator_cmd(void)
 {
     uint32_t timestamp = 0x12345678;
     can_msg_t output;
@@ -117,59 +117,13 @@ static bool test_valve_cmd(void)
     bool ret = true;
 
     // test illegal args
-    if (build_valve_cmd_msg(timestamp, VALVE_OPEN, MSG_DEBUG_MSG, &output)) {
-        REPORT_FAIL("Valve cmd built with invalid message type");
-        ret = false;
-    }
-    if (build_valve_cmd_msg(timestamp, VALVE_OPEN, MSG_INJ_VALVE_CMD, NULL)) {
+    if (build_actuator_cmd_msg(timestamp, ACTUATOR_VENT_VALVE, ACTUATOR_OPEN, NULL)) {
         REPORT_FAIL("Message built with null output");
         ret = false;
     }
 
     // test nominal behaviour
-    if (!build_valve_cmd_msg(timestamp, VALVE_OPEN, MSG_INJ_VALVE_CMD, &output)) {
-        REPORT_FAIL("Error building message");
-        ret = false;
-    }
-    if (output.data_len != 4) {
-        REPORT_FAIL("Data length is wrong");
-        ret = false;
-    }
-    if (get_timestamp(&output) != (timestamp & 0xffffff)) {
-        REPORT_FAIL("Timestamp copied wrong");
-        ret = false;
-    }
-    if (get_curr_valve_state(&output) != -1) {
-        REPORT_FAIL("Got current valve state from a command message");
-        ret = false;
-    }
-    if (get_req_valve_state(&output) != VALVE_OPEN) {
-        REPORT_FAIL("Valve data copied incorrectly");
-        ret = false;
-    }
-
-    return ret;
-}
-
-static bool test_valve_stat(void)
-{
-    uint32_t timestamp = 0x12345678;
-    can_msg_t output;
-
-    bool ret = true;
-
-    // test illegal args
-    if (build_valve_stat_msg(timestamp, VALVE_OPEN, VALVE_UNK, MSG_DEBUG_MSG, &output)) {
-        REPORT_FAIL("Valve cmd built with invalid message type");
-        ret = false;
-    }
-    if (build_valve_stat_msg(timestamp, VALVE_OPEN, VALVE_UNK, MSG_INJ_VALVE_STATUS, NULL)) {
-        REPORT_FAIL("Message built with null output");
-        ret = false;
-    }
-
-    // test nominal behaviour
-    if (!build_valve_stat_msg(timestamp, VALVE_OPEN, VALVE_CLOSED, MSG_INJ_VALVE_STATUS, &output)) {
+    if (!build_actuator_cmd_msg(timestamp, ACTUATOR_INJECTOR_VALVE, ACTUATOR_OPEN, &output)) {
         REPORT_FAIL("Error building message");
         ret = false;
     }
@@ -181,12 +135,58 @@ static bool test_valve_stat(void)
         REPORT_FAIL("Timestamp copied wrong");
         ret = false;
     }
-    if (get_curr_valve_state(&output) != VALVE_OPEN) {
-        REPORT_FAIL("Current valve state copied wrong");
+    if (get_actuator_id(&output) != ACTUATOR_INJECTOR_VALVE) {
+        REPORT_FAIL("Actuator id copied incorrectly");
         ret = false;
     }
-    if (get_req_valve_state(&output) != VALVE_CLOSED) {
-        REPORT_FAIL("Requested valve state copied wrong");
+    if (get_curr_actuator_state(&output) != -1) {
+        REPORT_FAIL("Got current actuator state from a command message");
+        ret = false;
+    }
+    if (get_req_actuator_state(&output) != ACTUATOR_OPEN) {
+        REPORT_FAIL("Actuator data copied incorrectly");
+        ret = false;
+    }
+
+    return ret;
+}
+
+static bool test_actuator_stat(void)
+{
+    uint32_t timestamp = 0x12345678;
+    can_msg_t output;
+
+    bool ret = true;
+
+    // test illegal args
+    if (build_actuator_stat_msg(timestamp, ACTUATOR_INJECTOR_VALVE, ACTUATOR_OPEN, ACTUATOR_UNK, NULL)) {
+        REPORT_FAIL("Message built with null output");
+        ret = false;
+    }
+
+    // test nominal behaviour
+    if (!build_actuator_stat_msg(timestamp, ACTUATOR_VENT_VALVE, ACTUATOR_OPEN, ACTUATOR_CLOSED, &output)) {
+        REPORT_FAIL("Error building message");
+        ret = false;
+    }
+    if (output.data_len != 6) {
+        REPORT_FAIL("Data length is wrong");
+        ret = false;
+    }
+    if (get_timestamp(&output) != (timestamp & 0xffffff)) {
+        REPORT_FAIL("Timestamp copied wrong");
+        ret = false;
+    }
+    if (get_actuator_id(&output) != ACTUATOR_VENT_VALVE) {
+        REPORT_FAIL("Current actuator state copied wrong");
+        ret = false;
+    }
+    if (get_curr_actuator_state(&output) != ACTUATOR_OPEN) {
+        REPORT_FAIL("Current actuator state copied wrong");
+        ret = false;
+    }
+    if (get_req_actuator_state(&output) != ACTUATOR_CLOSED) {
+        REPORT_FAIL("Requested actuator state copied wrong");
         ret = false;
     }
 
@@ -800,12 +800,12 @@ bool test_build_can_message(void)
         REPORT_FAIL("test_reset_command returned false");
         ret = false;
     }
-    if (!test_valve_cmd()) {
-        REPORT_FAIL("test_valve_cmd returned false");
+    if (!test_actuator_cmd()) {
+        REPORT_FAIL("test_actuator_cmd returned false");
         ret = false;
     }
-    if (!test_valve_stat()) {
-        REPORT_FAIL("test_valve_stat returned false");
+    if (!test_actuator_stat()) {
+        REPORT_FAIL("test_actuator_stat returned false");
         ret = false;
     }
     if (!test_arm_cmd()){


### PR DESCRIPTION
Removes the vent / injector valve message types, replaces them with a generic actuator message type that stores an actuator id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/canlib/37)
<!-- Reviewable:end -->
