### PR TITLE
CAN speedup 250 kbps

### DIFF
--- a/can.h
+++ b/can.h
@@ -10,7 +10,7 @@
 #include <stdbool.h>
 
 #define CANLIB_VERSION            "v0.7.0"
-#define CANLIB_BIT_TIME_US        24
+#define CANLIB_BIT_TIME_US        4
 
 // Timing parameters
 typedef struct {

--- a/util/timing_util.c
+++ b/util/timing_util.c
@@ -1,6 +1,6 @@
 #include "timing_util.h"
 
-#if (CANLIB_BIT_TIME_US != 24)
+#if (CANLIB_BIT_TIME_US != 4)
 #warning "the bit time that can.h is expecting is not what timing_util is expecting"
 #endif
 
@@ -9,16 +9,7 @@ bool can_generate_timing_params(uint32_t can_frequency, can_timing_t *timing)
     // this function is designed to create a bit time of 24 microseconds
     switch (can_frequency) {
         case 48000000:
-            timing->brp      = 47;
-            timing->sjw      =  3;
-            timing->btlmode  =  1;
-            timing->sam      =  0;
-            timing->seg1ph   =  4;
-            timing->prseg    =  0;
-            timing->seg2ph   =  4;
-            return true;
-        case 32000000:
-            timing->brp      = 31;
+            timing->brp      =  7;
             timing->sjw      =  3;
             timing->btlmode  =  1;
             timing->sam      =  0;
@@ -27,16 +18,7 @@ bool can_generate_timing_params(uint32_t can_frequency, can_timing_t *timing)
             timing->seg2ph   =  4;
             return true;
         case 12000000:
-            timing->brp      = 11;
-            timing->sjw      =  3;
-            timing->btlmode  =  1;
-            timing->sam      =  0;
-            timing->seg1ph   =  4;
-            timing->prseg    =  0;
-            timing->seg2ph   =  4;
-            return true;
-        case 1000000:
-            timing->brp      =  0;
+            timing->brp      =  1;
             timing->sjw      =  3;
             timing->btlmode  =  1;
             timing->sam      =  0;
@@ -45,7 +27,7 @@ bool can_generate_timing_params(uint32_t can_frequency, can_timing_t *timing)
             timing->seg2ph   =  4;
             return true;
         case 6000000:
-            timing->brp      =  5;
+            timing->brp      =  0;
             timing->sjw      =  3;
             timing->btlmode  =  1;
             timing->sam      =  0;

--- a/util/timing_util.c
+++ b/util/timing_util.c
@@ -6,7 +6,7 @@
 
 bool can_generate_timing_params(uint32_t can_frequency, can_timing_t *timing)
 {
-    // this function is designed to create a bit time of 24 microseconds
+    // this function is designed to create a bit time of 4 microseconds
     switch (can_frequency) {
         case 48000000:
             timing->brp      =  7;


### PR DESCRIPTION
Removed 32 MHz and 1MHz system clock option due to incompatibility

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/canlib/51)
<!-- Reviewable:end -->
