### PR TITLE
modified analog actuator CAN message to take uint8_t rather than float

### DIFF
--- a/can_common.c
+++ b/can_common.c
@@ -125,7 +125,7 @@ bool build_actuator_stat_msg(uint32_t timestamp,
 
 bool build_actuator_cmd_analog(uint32_t timestamp,
 								 enum ACTUATOR_ID actuator_id,
-								 float actuator_cmd,
+								 uint8_t actuator_cmd,
 								 can_msg_t *output)
 {
 	if(!output) { return false; }
@@ -134,7 +134,7 @@ bool build_actuator_cmd_analog(uint32_t timestamp,
 	write_timestamp_3bytes(timestamp, output);
 
 	output->data[3] = actuator_id;
-	memcpy(output->data + 4, &actuator_cmd, sizeof(actuator_cmd));
+	output->data[4] = actuator_cmd;
 
 	output->data_len = 8;
 	

--- a/can_common.c
+++ b/can_common.c
@@ -546,21 +546,18 @@ int get_req_actuator_state(const can_msg_t *msg)
     }
 }
 
-float get_req_actuator_state_analog(const can_msg_t *msg)
+int get_req_actuator_state_analog(const can_msg_t *msg)
 {
     if (!msg) { return -1; }
 
     uint16_t msg_type = get_message_type(msg);
-	float value;
-
 	switch (msg_type) {
         case MSG_ACT_ANALOG_CMD:
-        	memcpy(&value, msg->data+4, sizeof(value));
-            return value;
+            return msg->data[4];
 
         default:
             // not a valid field for this message type
-            return -1.0;
+            return -1;
     }
 }
 

--- a/can_common.c
+++ b/can_common.c
@@ -136,7 +136,7 @@ bool build_actuator_cmd_analog(uint32_t timestamp,
 	output->data[3] = actuator_id;
 	output->data[4] = actuator_cmd;
 
-	output->data_len = 8;
+	output->data_len = 5;
 	
 	return true;
 }
@@ -546,9 +546,9 @@ int get_req_actuator_state(const can_msg_t *msg)
     }
 }
 
-int get_req_actuator_state_analog(const can_msg_t *msg)
+uint8_t get_req_actuator_state_analog(const can_msg_t *msg)
 {
-    if (!msg) { return -1; }
+    if (!msg) { return 0; }
 
     uint16_t msg_type = get_message_type(msg);
 	switch (msg_type) {
@@ -557,7 +557,7 @@ int get_req_actuator_state_analog(const can_msg_t *msg)
 
         default:
             // not a valid field for this message type
-            return -1;
+            return 0;
     }
 }
 

--- a/can_common.h
+++ b/can_common.h
@@ -267,7 +267,7 @@ int get_req_actuator_state(const can_msg_t *msg);
  * command or status message. Returns -1.0 if the provided message is not
  * an actuator cmd/status.
  */
-float get_req_actuator_state_analog(const can_msg_t *msg);
+uint8_t get_req_actuator_state_analog(const can_msg_t *msg);
 
 /*
 * Gets the current arm state and which altimeter it is for.

--- a/can_common.h
+++ b/can_common.h
@@ -91,7 +91,7 @@ bool build_actuator_stat_msg(uint32_t timestamp,
  */
 bool build_actuator_cmd_analog(uint32_t timestamp,
 							   enum ACTUATOR_ID actuator_id,
-							   float actuator_cmd,
+							   uint8_t actuator_cmd,
 							   can_msg_t *output);
 
 /*

--- a/message_types.h
+++ b/message_types.h
@@ -92,7 +92,7 @@
  * ACTUATOR_CMD:    TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ACTUATOR_ID           ACTUATOR_STATE   None               None             None
  * ALT_ARM_CMD:     TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ALT_ARM_STATE & #     None             None               None             None
  * RESET_CMD:       TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L BOARD_ID              None             None               None             None
- * ACT_ANALOG_CMD:  TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ACTUATOR_ID           ACTUATOR_STATE_INT None             None             None
+ * ACT_ANALOG_CMD:  TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ACTUATOR_ID           ACT_STATE_INT    None               None             None
  *
  * DEBUG_MSG:       TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L DEBUG_LEVEL | LINUM_H LINUM_L          MESSAGE_DEFINED    MESSAGE_DEFINED  MESSAGE_DEFINED
  * DEBUG_PRINTF:    ASCII       ASCII       ASCII       ASCII                 ASCII            ASCII              ASCII            ASCII

--- a/message_types.h
+++ b/message_types.h
@@ -92,7 +92,7 @@
  * ACTUATOR_CMD:    TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ACTUATOR_ID           ACTUATOR_STATE   None               None             None
  * ALT_ARM_CMD:     TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ALT_ARM_STATE & #     None             None               None             None
  * RESET_CMD:       TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L BOARD_ID              None             None               None             None
- * ACT_ANALOG_CMD:  TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ACTUATOR_ID           ACTUATOR_STATE_H ACTUATOR_STATE_MH  ACTUATOR_STATE_ML ACTUATOR_STATE_L
+ * ACT_ANALOG_CMD:  TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L ACTUATOR_ID           ACTUATOR_STATE_INT None             None             None
  *
  * DEBUG_MSG:       TSTAMP_MS_H TSTAMP_MS_M TSTAMP_MS_L DEBUG_LEVEL | LINUM_H LINUM_L          MESSAGE_DEFINED    MESSAGE_DEFINED  MESSAGE_DEFINED
  * DEBUG_PRINTF:    ASCII       ASCII       ASCII       ASCII                 ASCII            ASCII              ASCII            ASCII


### PR DESCRIPTION
- modified actuator-analog-cmd in message_types.h to use uint8_t and 3 null bytes, replacing a 4-byte float
- modified build-actuator-analog-cmd prototype in can_common.h to build can message with above format
- modified build-actuator-analog-cmd in can_common.c to build can message with above format