### PR TITLE
Fix apogee data byte order in calibration messages

### DIFF
--- a/can_common.c
+++ b/can_common.c
@@ -854,7 +854,7 @@ bool get_state_est_calibration_msg(const can_msg_t *msg,
 	if (get_message_type(msg) != MSG_STATE_EST_CALIB) { return false; }
 
 	*ack_flag = msg->data[3];
-	*apogee = msg->data[5] << 8 | msg->data[4];
+	*apogee = msg->data[4] << 8 | msg->data[5];
 
 	return true;
 }


### PR DESCRIPTION
The apogee data bytes were flipped the wrong way around. I fixed them.