### PR TITLE
Update lint flow

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -x
-clang-format -i message/*.h message/*.c util/*.h util/*.c stm32h7/*.h stm32h7/*.c pic18f26k83/*.h pic18f26k83/*.c mcp2515/*.h mcp2515/*.c dspic33epxxxgp50x/*.h dspic33epxxxgp50x/*.c
+${CLANG_FORMAT:-clang-format} -i message/*.h message/*.c util/*.h util/*.c stm32h7/*.h stm32h7/*.c pic18f26k83/*.h pic18f26k83/*.c mcp2515/*.h mcp2515/*.c dspic33epxxxgp50x/*.h dspic33epxxxgp50x/*.c

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -x
-clang-tidy-21 message/*.h message/*.c util/*.h util/*.c mcp2515/*.h mcp2515/*.c dspic33epxxxgp50x/*.h pic18f26k83/*.h --warnings-as-errors="*,-clang-diagnostic-c23-extensions" --checks="clang-*,misc-*"
+${CLANG_TIDY:-clang-tidy} message/*.h message/*.c util/*.h util/*.c mcp2515/*.h mcp2515/*.c dspic33epxxxgp50x/*.h pic18f26k83/*.h --warnings-as-errors="*,-clang-diagnostic-c23-extensions" --checks="clang-*,misc-*"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -x
-${CLANG_TIDY:-clang-tidy} message/*.h message/*.c util/*.h util/*.c mcp2515/*.h mcp2515/*.c dspic33epxxxgp50x/*.h pic18f26k83/*.h --warnings-as-errors="*,-clang-diagnostic-c23-extensions" --checks="clang-*,misc-*"
+${CLANG_TIDY:-clang-tidy} message/*.h message/*.c util/*.h util/*.c mcp2515/*.h mcp2515/*.c dspic33epxxxgp50x/*.h pic18f26k83/*.h --warnings-as-errors="*,-clang-diagnostic-c23-extensions" --checks="clang-*,misc-*" --extra-arg-before="-std=c99" --extra-arg-before="-pedantic" --extra-arg-before="-I." --extra-arg-before="-DBOARD_TYPE_UNIQUE_ID=BOARD_TYPE_ID_ARMING" --extra-arg-before="-DBOARD_INST_UNIQUE_ID=BOARD_INST_ID_ROCKET"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -x
-clang-tidy message/*.h message/*.c util/*.h util/*.c mcp2515/*.h mcp2515/*.c dspic33epxxxgp50x/*.h pic18f26k83/*.h
+clang-tidy-21 message/*.h message/*.c util/*.h util/*.c mcp2515/*.h mcp2515/*.c dspic33epxxxgp50x/*.h pic18f26k83/*.h --warnings-as-errors="*,-clang-diagnostic-c23-extensions" --checks="clang-*,misc-*"


### PR DESCRIPTION
Note I did not add lint check to GitHub Action because the lint flow depends on clang compilation database, which take a lot of work to setup.