### PR TITLE
Fix copy+pasted nullptr check assert in get_2d_analog_sensor_data_24bit

### DIFF
--- a/message/msg_sensor.c
+++ b/message/msg_sensor.c
@@ -148,7 +148,7 @@ bool get_2d_analog_sensor_data_24bit(const can_msg_t *msg, can_dem_2d_sensor_id_
 	w_assert(msg);
 	w_assert(sensor_id);
 	w_assert(sensor_data_x);
-	w_assert(sensor_data_x);
+	w_assert(sensor_data_y);
 
 	if (get_message_type(msg) != MSG_SENSOR_2D_ANALOG24) {
 		return false;


### PR DESCRIPTION
My bad I missed this cause when I re-ran the new nullptr tests I still had stuff commented out. They pass now with this fixed though