### PR TITLE
Check returned status from message parsing functions in tests where m…

### DIFF
--- a/tests/test_msg_actuator.cpp
+++ b/tests/test_msg_actuator.cpp
@@ -56,10 +56,10 @@ public:
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 2;
 
-		w_status_t parse_status = get_actuator_id(&invalid_len_msg, &actuator_id_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
-		parse_status = get_cmd_actuator_state(&invalid_len_msg, &actuator_state_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_actuator_id(&invalid_len_msg, &actuator_id_after) ==
+								   W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_cmd_actuator_state(&invalid_len_msg, &actuator_state_after) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -127,17 +127,20 @@ public:
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 3;
 
-		w_status_t parse_status = get_actuator_id(&invalid_len_msg, &actuator_id_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
-		parse_status = get_curr_actuator_state(&invalid_len_msg, &actuator_curr_state_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
-		parse_status = get_cmd_actuator_state(&invalid_len_msg, &actuator_curr_state_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_actuator_id(&invalid_len_msg, &actuator_id_after) ==
+								   W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_curr_actuator_state(&invalid_len_msg, &actuator_curr_state_after) ==
+			W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_cmd_actuator_state(&invalid_len_msg, &actuator_curr_state_after) ==
+			W_DATA_FORMAT_ERROR);
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_ACTUATOR_CMD, actuator_id_before);
-		parse_status = get_curr_actuator_state(&invalid_type_msg, &actuator_curr_state_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_curr_actuator_state(&invalid_type_msg, &actuator_curr_state_after) ==
+			W_INVALID_PARAM);
 
 		return test_passed;
 	}
@@ -169,11 +172,10 @@ public:
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_GENERAL_BOARD_STATUS, actuator_id_before);
 
-		w_status_t parse_status = get_actuator_id(&invalid_type_msg, &actuator_id_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
-
-		parse_status = get_cmd_actuator_state(&invalid_type_msg, &actuator_state_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_actuator_id(&invalid_type_msg, &actuator_id_after) ==
+								   W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_cmd_actuator_state(&invalid_type_msg, &actuator_state_after) == W_INVALID_PARAM);
 
 		return test_passed;
 	}

--- a/tests/test_msg_canards.cpp
+++ b/tests/test_msg_canards.cpp
@@ -65,15 +65,17 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_SENSOR_ANALOG32, 0);
-		w_status_t parse_status = get_canard_firmware_error_msg(
-			&invalid_type_msg, &module_id_after, &error_bitfield_after, &severity_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_canard_firmware_error_msg(
+				&invalid_type_msg, &module_id_after, &error_bitfield_after, &severity_after) ==
+			W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 3;
-		parse_status = get_canard_firmware_error_msg(
-			&invalid_len_msg, &module_id_after, &error_bitfield_after, &severity_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_canard_firmware_error_msg(
+				&invalid_len_msg, &module_id_after, &error_bitfield_after, &severity_after) ==
+			W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}

--- a/tests/test_msg_general.cpp
+++ b/tests/test_msg_general.cpp
@@ -104,10 +104,9 @@ public:
 
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		w_status_t parse_status =
-			get_reset_board_id(&msg, &board_type_id_after, &board_inst_id_after);
+		rockettest_check_expr_true(
+			get_reset_board_id(&msg, &board_type_id_after, &board_inst_id_after) == W_SUCCESS);
 
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
 		rockettest_check_expr_true(type_after == MSG_RESET_CMD);
 		rockettest_check_expr_true(timestamp_after == timestamp_before);
 		rockettest_check_expr_true(board_type_id_after == board_type_id_before);
@@ -119,12 +118,12 @@ public:
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 3;
 
-		parse_status =
-			get_reset_board_id(&invalid_type_msg, &board_type_id_after, &board_inst_id_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
-		parse_status =
-			get_reset_board_id(&invalid_len_msg, &board_type_id_after, &board_inst_id_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_reset_board_id(&invalid_type_msg,
+													  &board_type_id_after,
+													  &board_inst_id_after) == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_reset_board_id(&invalid_len_msg,
+													  &board_type_id_after,
+													  &board_inst_id_after) == W_DATA_FORMAT_ERROR);
 
 		// Test check_board_need_reset()
 		// Tests are compiled with BOARD_TYPE_UNIQUE_ID=BOARD_TYPE_ID_ARMING and
@@ -134,39 +133,34 @@ public:
 
 		// Type any
 		build_reset_msg(prio, timestamp_before, BOARD_TYPE_ID_ANY, board_inst_id_before, &msg);
-		parse_status = check_board_need_reset(&msg, &board_need_reset);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(check_board_need_reset(&msg, &board_need_reset) == W_SUCCESS);
 		rockettest_check_expr_true(board_need_reset);
 
 		// Type matching, inst any
 		build_reset_msg(prio, timestamp_before, BOARD_TYPE_UNIQUE_ID, BOARD_INST_ID_ANY, &msg);
-		parse_status = check_board_need_reset(&msg, &board_need_reset);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(check_board_need_reset(&msg, &board_need_reset) == W_SUCCESS);
 		rockettest_check_expr_true(board_need_reset);
 
 		// Type matching, inst matching
 		build_reset_msg(prio, timestamp_before, BOARD_TYPE_UNIQUE_ID, BOARD_INST_UNIQUE_ID, &msg);
-		parse_status = check_board_need_reset(&msg, &board_need_reset);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(check_board_need_reset(&msg, &board_need_reset) == W_SUCCESS);
 		rockettest_check_expr_true(board_need_reset);
 
 		// Type matching, inst not matching
 		build_reset_msg(prio, timestamp_before, BOARD_TYPE_UNIQUE_ID, BOARD_INST_ID_GROUND, &msg);
-		parse_status = check_board_need_reset(&msg, &board_need_reset);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(check_board_need_reset(&msg, &board_need_reset) == W_SUCCESS);
 		rockettest_check_expr_true(!board_need_reset);
 
 		// Type not matching
 		build_reset_msg(
 			prio, timestamp_before, BOARD_TYPE_ID_ALTIMETER, BOARD_INST_UNIQUE_ID, &msg);
-		parse_status = check_board_need_reset(&msg, &board_need_reset);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(check_board_need_reset(&msg, &board_need_reset) == W_SUCCESS);
 		rockettest_check_expr_true(!board_need_reset);
 
-		parse_status = check_board_need_reset(&invalid_type_msg, &board_need_reset);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
-		parse_status = check_board_need_reset(&invalid_len_msg, &board_need_reset);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(check_board_need_reset(&invalid_type_msg, &board_need_reset) ==
+								   W_INVALID_PARAM);
+		rockettest_check_expr_true(check_board_need_reset(&invalid_len_msg, &board_need_reset) ==
+								   W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -208,8 +202,7 @@ public:
 
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		w_status_t parse_status = get_debug_raw_data(&msg, data_after);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(get_debug_raw_data(&msg, data_after) == W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_DEBUG_RAW)
 			rockettest_check_expr_true(timestamp_after == timestamp_before);
@@ -219,13 +212,13 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio, MSG_GENERAL_BOARD_STATUS, 0);
-		parse_status = get_debug_raw_data(&invalid_type_msg, data_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_debug_raw_data(&invalid_type_msg, data_after) ==
+								   W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 7;
-		parse_status = get_debug_raw_data(&invalid_len_msg, data_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_debug_raw_data(&invalid_len_msg, data_after) ==
+								   W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -282,11 +275,11 @@ public:
 		std::uint16_t config_value_after;
 
 		type_after = get_message_type(&msg);
-		w_status_t parse_status =
-			get_config_set_target_board(&msg, &board_type_id_after, &board_inst_id_after);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
-		parse_status = get_config_id_value(&msg, &config_id_after, &config_value_after);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(get_config_set_target_board(&msg,
+															   &board_type_id_after,
+															   &board_inst_id_after) == W_SUCCESS);
+		rockettest_check_expr_true(
+			get_config_id_value(&msg, &config_id_after, &config_value_after) == W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_CONFIG_SET);
 		rockettest_check_expr_true(board_type_id_after == board_type_id_before);
@@ -296,17 +289,19 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio, MSG_CONFIG_STATUS, 0);
-		parse_status = get_config_set_target_board(
-			&invalid_type_msg, &board_type_id_after, &board_inst_id_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_config_set_target_board(
+				&invalid_type_msg, &board_type_id_after, &board_inst_id_after) == W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 7;
-		parse_status = get_config_set_target_board(
-			&invalid_len_msg, &board_type_id_after, &board_inst_id_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
-		parse_status = get_config_id_value(&invalid_len_msg, &config_id_after, &config_value_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_config_set_target_board(&invalid_len_msg,
+															   &board_type_id_after,
+															   &board_inst_id_after) ==
+								   W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_config_id_value(&invalid_len_msg,
+													   &config_id_after,
+													   &config_value_after) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -348,8 +343,8 @@ public:
 		std::uint16_t config_value_after;
 
 		type_after = get_message_type(&msg);
-		w_status_t parse_status = get_config_id_value(&msg, &config_id_after, &config_value_after);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(
+			get_config_id_value(&msg, &config_id_after, &config_value_after) == W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_CONFIG_STATUS);
 		rockettest_check_expr_true(config_id_after == config_id_before);
@@ -357,8 +352,9 @@ public:
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 5;
-		parse_status = get_config_id_value(&invalid_len_msg, &config_id_after, &config_value_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_config_id_value(&invalid_len_msg,
+													   &config_id_after,
+													   &config_value_after) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -388,9 +384,9 @@ public:
 		std::uint16_t config_id_after;
 		std::uint16_t config_value_after;
 
-		w_status_t parse_status =
-			get_config_id_value(&invalid_type_msg, &config_id_after, &config_value_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_config_id_value(&invalid_type_msg,
+													   &config_id_after,
+													   &config_value_after) == W_INVALID_PARAM);
 
 		return test_passed;
 	}

--- a/tests/test_msg_gps.cpp
+++ b/tests/test_msg_gps.cpp
@@ -60,7 +60,10 @@ public:
 
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_gps_time(&msg, &utc_hours_after, &utc_mins_after, &utc_secs_after, &utc_dsecs_after);
+		rockettest_check_expr_true(
+			get_gps_time(
+				&msg, &utc_hours_after, &utc_mins_after, &utc_secs_after, &utc_dsecs_after) ==
+			W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_GPS_TIMESTAMP);
 		rockettest_check_expr_true(timestamp_after == timestamp_before);
@@ -71,18 +74,19 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_GPS_LATITUDE, 0);
-		w_status_t parse_status = get_gps_time(&invalid_type_msg,
-											   &utc_hours_after,
-											   &utc_mins_after,
-											   &utc_secs_after,
-											   &utc_dsecs_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_gps_time(&invalid_type_msg,
+												&utc_hours_after,
+												&utc_mins_after,
+												&utc_secs_after,
+												&utc_dsecs_after) == W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 5;
-		parse_status = get_gps_time(
-			&invalid_len_msg, &utc_hours_after, &utc_mins_after, &utc_secs_after, &utc_dsecs_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_gps_time(&invalid_len_msg,
+												&utc_hours_after,
+												&utc_mins_after,
+												&utc_secs_after,
+												&utc_dsecs_after) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -142,7 +146,9 @@ public:
 
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_gps_lat(&msg, &degrees_after, &minutes_after, &dminutes_after, &direction_after);
+		rockettest_check_expr_true(
+			get_gps_lat(&msg, &degrees_after, &minutes_after, &dminutes_after, &direction_after) ==
+			W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_GPS_LATITUDE);
 		rockettest_check_expr_true(timestamp_after == timestamp_before);
@@ -153,15 +159,19 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_GPS_TIMESTAMP, 0);
-		w_status_t parse_status = get_gps_lat(
-			&invalid_type_msg, &degrees_after, &minutes_after, &dminutes_after, &direction_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_gps_lat(&invalid_type_msg,
+											   &degrees_after,
+											   &minutes_after,
+											   &dminutes_after,
+											   &direction_after) == W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 6;
-		parse_status = get_gps_lat(
-			&invalid_len_msg, &degrees_after, &minutes_after, &dminutes_after, &direction_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_gps_lat(&invalid_len_msg,
+											   &degrees_after,
+											   &minutes_after,
+											   &dminutes_after,
+											   &direction_after) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -221,7 +231,9 @@ public:
 
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_gps_lon(&msg, &degrees_after, &minutes_after, &dminutes_after, &direction_after);
+		rockettest_check_expr_true(
+			get_gps_lon(&msg, &degrees_after, &minutes_after, &dminutes_after, &direction_after) ==
+			W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_GPS_LONGITUDE);
 		rockettest_check_expr_true(timestamp_after == timestamp_before);
@@ -232,16 +244,19 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_GPS_TIMESTAMP, 0);
-		w_status_t parse_status = get_gps_lon(
-			&invalid_type_msg, &degrees_after, &minutes_after, &dminutes_after, &direction_after);
-		;
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_gps_lon(&invalid_type_msg,
+											   &degrees_after,
+											   &minutes_after,
+											   &dminutes_after,
+											   &direction_after) == W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 6;
-		parse_status = get_gps_lon(
-			&invalid_len_msg, &degrees_after, &minutes_after, &dminutes_after, &direction_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_gps_lon(&invalid_len_msg,
+											   &degrees_after,
+											   &minutes_after,
+											   &dminutes_after,
+											   &direction_after) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -287,7 +302,8 @@ public:
 
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_gps_alt(&msg, &altitude_after, &daltitude_after);
+		rockettest_check_expr_true(get_gps_alt(&msg, &altitude_after, &daltitude_after) ==
+								   W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_GPS_ALTITUDE);
 		rockettest_check_expr_true(timestamp_after == timestamp_before);
@@ -296,13 +312,14 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_GPS_TIMESTAMP, 0);
-		w_status_t parse_status = get_gps_alt(&invalid_type_msg, &altitude_after, &daltitude_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_gps_alt(&invalid_type_msg, &altitude_after, &daltitude_after) == W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 6;
-		parse_status = get_gps_alt(&invalid_len_msg, &altitude_after, &daltitude_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_gps_alt(&invalid_len_msg,
+											   &altitude_after,
+											   &daltitude_after) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -346,7 +363,7 @@ public:
 
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_gps_info(&msg, &num_sat_after, &quality_after);
+		rockettest_check_expr_true(get_gps_info(&msg, &num_sat_after, &quality_after) == W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_GPS_INFO);
 		rockettest_check_expr_true(timestamp_after == timestamp_before);
@@ -355,13 +372,13 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_GPS_TIMESTAMP, 0);
-		w_status_t parse_status = get_gps_info(&invalid_type_msg, &num_sat_after, &quality_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_gps_info(&invalid_type_msg, &num_sat_after, &quality_after) == W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 3;
-		parse_status = get_gps_info(&invalid_len_msg, &num_sat_after, &quality_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_gps_info(&invalid_len_msg, &num_sat_after, &quality_after) ==
+								   W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}

--- a/tests/test_msg_recovery.cpp
+++ b/tests/test_msg_recovery.cpp
@@ -42,7 +42,8 @@ public:
 
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_alt_arm_state(&msg, &alt_id_after, &alt_arm_state_after);
+		rockettest_check_expr_true(get_alt_arm_state(&msg, &alt_id_after, &alt_arm_state_after) ==
+								   W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_ALT_ARM_CMD);
 		rockettest_check_expr_true(timestamp_after == timestamp_before);
@@ -51,9 +52,9 @@ public:
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 2;
-		w_status_t parse_status =
-			get_alt_arm_state(&invalid_len_msg, &alt_id_after, &alt_arm_state_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_alt_arm_state(&invalid_len_msg,
+													 &alt_id_after,
+													 &alt_arm_state_after) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -112,8 +113,10 @@ public:
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
 
-		get_alt_arm_state(&msg, &alt_id_after, &alt_arm_state_after);
-		get_pyro_voltage_data(&msg, &v_drogue_after, &v_main_after);
+		rockettest_check_expr_true(get_alt_arm_state(&msg, &alt_id_after, &alt_arm_state_after) ==
+								   W_SUCCESS);
+		rockettest_check_expr_true(get_pyro_voltage_data(&msg, &v_drogue_after, &v_main_after) ==
+								   W_SUCCESS);
 
 		rockettest_check_expr_true(type_after == MSG_ALT_ARM_STATUS);
 		rockettest_check_expr_true(timestamp_after == timestamp_before);
@@ -125,17 +128,19 @@ public:
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 6;
 
-		w_status_t parse_status =
-			get_alt_arm_state(&invalid_len_msg, &alt_id_after, &alt_arm_state_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_alt_arm_state(&invalid_len_msg,
+													 &alt_id_after,
+													 &alt_arm_state_after) == W_DATA_FORMAT_ERROR);
 
-		parse_status = get_pyro_voltage_data(&invalid_len_msg, &v_drogue_after, &v_main_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_pyro_voltage_data(&invalid_len_msg,
+														 &v_drogue_after,
+														 &v_main_after) == W_DATA_FORMAT_ERROR);
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_ALT_ARM_CMD, alt_id_before);
-		parse_status = get_pyro_voltage_data(&invalid_type_msg, &v_drogue_after, &v_main_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_pyro_voltage_data(&invalid_type_msg,
+														 &v_drogue_after,
+														 &v_main_after) == W_INVALID_PARAM);
 
 		return test_passed;
 	}
@@ -173,9 +178,9 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_GENERAL_BOARD_STATUS, alt_id_before);
-		w_status_t parse_status =
-			get_alt_arm_state(&invalid_type_msg, &alt_id_after, &alt_arm_state_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_alt_arm_state(&invalid_type_msg,
+													 &alt_id_after,
+													 &alt_arm_state_after) == W_INVALID_PARAM);
 
 		return test_passed;
 	}

--- a/tests/test_msg_sensor.cpp
+++ b/tests/test_msg_sensor.cpp
@@ -50,7 +50,8 @@ public:
 		msg_is_sensor_data_after = msg_is_analog_sensor(&msg);
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_analog_sensor_data_16bit(&msg, &sensor_id_after, &sensor_data_after);
+		rockettest_check_expr_true(
+			get_analog_sensor_data_16bit(&msg, &sensor_id_after, &sensor_data_after) == W_SUCCESS);
 
 		rockettest_check_expr_true(msg_is_sensor_data_after == true);
 		rockettest_check_expr_true(type_after == MSG_SENSOR_ANALOG16);
@@ -60,15 +61,15 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_SENSOR_ANALOG32, sensor_id_before);
-		w_status_t parse_status =
-			get_analog_sensor_data_16bit(&invalid_type_msg, &sensor_id_after, &sensor_data_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_analog_sensor_data_16bit(&invalid_type_msg, &sensor_id_after, &sensor_data_after) ==
+			W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 3;
-		parse_status =
-			get_analog_sensor_data_16bit(&invalid_len_msg, &sensor_id_after, &sensor_data_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_analog_sensor_data_16bit(&invalid_len_msg, &sensor_id_after, &sensor_data_after) ==
+			W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -118,7 +119,8 @@ public:
 		msg_is_sensor_data_after = msg_is_analog_sensor(&msg);
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_analog_sensor_data_32bit(&msg, &sensor_id_after, &sensor_data_after);
+		rockettest_check_expr_true(
+			get_analog_sensor_data_32bit(&msg, &sensor_id_after, &sensor_data_after) == W_SUCCESS);
 
 		rockettest_check_expr_true(msg_is_sensor_data_after == true);
 		rockettest_check_expr_true(type_after == MSG_SENSOR_ANALOG32);
@@ -128,15 +130,15 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_SENSOR_ANALOG16, sensor_id_before);
-		w_status_t parse_status =
-			get_analog_sensor_data_32bit(&invalid_type_msg, &sensor_id_after, &sensor_data_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_analog_sensor_data_32bit(&invalid_type_msg, &sensor_id_after, &sensor_data_after) ==
+			W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 5;
-		parse_status =
-			get_analog_sensor_data_32bit(&invalid_len_msg, &sensor_id_after, &sensor_data_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_analog_sensor_data_32bit(&invalid_len_msg, &sensor_id_after, &sensor_data_after) ==
+			W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -197,11 +199,12 @@ public:
 		msg_is_sensor_data_after = msg_is_analog_sensor(&msg);
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_3d_analog_sensor_data_16bit(&msg,
-										&sensor_id_after,
-										&sensor_data_x_after,
-										&sensor_data_y_after,
-										&sensor_data_z_after);
+		rockettest_check_expr_true(get_3d_analog_sensor_data_16bit(&msg,
+																   &sensor_id_after,
+																   &sensor_data_x_after,
+																   &sensor_data_y_after,
+																   &sensor_data_z_after) ==
+								   W_SUCCESS);
 
 		rockettest_check_expr_true(msg_is_sensor_data_after == true);
 		rockettest_check_expr_true(type_after == MSG_SENSOR_3D_ANALOG16);
@@ -213,21 +216,21 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_SENSOR_2D_ANALOG24, sensor_id_before);
-		w_status_t parse_status = get_3d_analog_sensor_data_16bit(&invalid_type_msg,
-																  &sensor_id_after,
-																  &sensor_data_x_after,
-																  &sensor_data_y_after,
-																  &sensor_data_z_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_3d_analog_sensor_data_16bit(&invalid_type_msg,
+																   &sensor_id_after,
+																   &sensor_data_x_after,
+																   &sensor_data_y_after,
+																   &sensor_data_z_after) ==
+								   W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 7;
-		parse_status = get_3d_analog_sensor_data_16bit(&invalid_len_msg,
-													   &sensor_id_after,
-													   &sensor_data_x_after,
-													   &sensor_data_y_after,
-													   &sensor_data_z_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_3d_analog_sensor_data_16bit(&invalid_len_msg,
+																   &sensor_id_after,
+																   &sensor_data_x_after,
+																   &sensor_data_y_after,
+																   &sensor_data_z_after) ==
+								   W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -284,8 +287,9 @@ public:
 		msg_is_sensor_data_after = msg_is_analog_sensor(&msg);
 		type_after = get_message_type(&msg);
 		timestamp_after = get_timestamp(&msg);
-		get_2d_analog_sensor_data_24bit(
-			&msg, &sensor_id_after, &sensor_data_x_after, &sensor_data_y_after);
+		rockettest_check_expr_true(
+			get_2d_analog_sensor_data_24bit(
+				&msg, &sensor_id_after, &sensor_data_x_after, &sensor_data_y_after) == W_SUCCESS);
 
 		rockettest_check_expr_true(msg_is_sensor_data_after == true);
 		rockettest_check_expr_true(type_after == MSG_SENSOR_2D_ANALOG24);
@@ -314,15 +318,17 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_SENSOR_ANALOG32, sensor_id_before);
-		w_status_t parse_status = get_2d_analog_sensor_data_24bit(
-			&invalid_type_msg, &sensor_id_after, &sensor_data_x_after, &sensor_data_y_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_2d_analog_sensor_data_24bit(
+				&invalid_type_msg, &sensor_id_after, &sensor_data_x_after, &sensor_data_y_after) ==
+			W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 7;
-		parse_status = get_2d_analog_sensor_data_24bit(
-			&invalid_len_msg, &sensor_id_after, &sensor_data_x_after, &sensor_data_y_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_2d_analog_sensor_data_24bit(
+				&invalid_len_msg, &sensor_id_after, &sensor_data_x_after, &sensor_data_y_after) ==
+			W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}

--- a/tests/test_msg_stream.cpp
+++ b/tests/test_msg_stream.cpp
@@ -43,20 +43,21 @@ public:
 
 		std::uint32_t total_size_out = 0;
 		std::uint32_t tx_size_out = 0;
-		w_status_t parse_status = get_stream_status(&msg, &total_size_out, &tx_size_out);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(get_stream_status(&msg, &total_size_out, &tx_size_out) ==
+								   W_SUCCESS);
 		rockettest_check_expr_true(total_size_out == total_size);
 		rockettest_check_expr_true(tx_size_out == tx_size);
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio, MSG_STREAM_DATA, 0);
-		parse_status = get_stream_status(&invalid_type_msg, &total_size_out, &tx_size_out);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_stream_status(&invalid_type_msg, &total_size_out, &tx_size_out) == W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 7;
-		parse_status = get_stream_status(&invalid_len_msg, &total_size_out, &tx_size_out);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_stream_status(&invalid_len_msg,
+													 &total_size_out,
+													 &tx_size_out) == W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}
@@ -97,8 +98,8 @@ public:
 		std::uint8_t payload_out[STREAM_DATA_MAX_PAYLOAD_LEN] = {};
 		std::uint8_t payload_len_out = 0;
 
-		w_status_t parse_status = get_stream_data(&msg, &seq_id_out, payload_out, &payload_len_out);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(
+			get_stream_data(&msg, &seq_id_out, payload_out, &payload_len_out) == W_SUCCESS);
 		rockettest_check_expr_true(seq_id_out == seq_id);
 		rockettest_check_expr_true(payload_len_out == payload_len);
 		rockettest_check_expr_true(std::memcmp(payload_out, payload, payload_len) == 0);
@@ -107,21 +108,21 @@ public:
 		invalid_len_msg.sid = build_sid(prio, MSG_STREAM_DATA, seq_id);
 		// Too short data_len
 		invalid_len_msg.data_len = 2;
-		parse_status =
-			get_stream_data(&invalid_len_msg, &seq_id_out, payload_out, &payload_len_out);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_stream_data(&invalid_len_msg, &seq_id_out, payload_out, &payload_len_out) ==
+			W_DATA_FORMAT_ERROR);
 		// Too long data_len
 		invalid_len_msg.data_len = 9;
-		parse_status =
-			get_stream_data(&invalid_len_msg, &seq_id_out, payload_out, &payload_len_out);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_stream_data(&invalid_len_msg, &seq_id_out, payload_out, &payload_len_out) ==
+			W_DATA_FORMAT_ERROR);
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio, MSG_STREAM_RETRY, seq_id);
 		invalid_type_msg.data_len = msg.data_len;
-		parse_status =
-			get_stream_data(&invalid_type_msg, &seq_id_out, payload_out, &payload_len_out);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_stream_data(&invalid_type_msg, &seq_id_out, payload_out, &payload_len_out) ==
+			W_INVALID_PARAM);
 
 		return test_passed;
 	}
@@ -148,19 +149,18 @@ public:
 		rockettest_check_expr_true((msg.sid & 0xff) == seq_id);
 
 		std::uint8_t seq_id_out = 0;
-		w_status_t parse_status = get_stream_retry_seq_id(&msg, &seq_id_out);
-		rockettest_check_expr_true(parse_status == W_SUCCESS);
+		rockettest_check_expr_true(get_stream_retry_seq_id(&msg, &seq_id_out) == W_SUCCESS);
 		rockettest_check_expr_true(seq_id_out == seq_id);
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio, MSG_STREAM_STATUS, seq_id);
-		parse_status = get_stream_retry_seq_id(&invalid_type_msg, &seq_id_out);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(get_stream_retry_seq_id(&invalid_type_msg, &seq_id_out) ==
+								   W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 3;
-		parse_status = get_stream_retry_seq_id(&invalid_len_msg, &seq_id_out);
-		rockettest_check_expr_true(W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(get_stream_retry_seq_id(&invalid_len_msg, &seq_id_out) ==
+								   W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}

--- a/tests/test_msg_telemetry.cpp
+++ b/tests/test_msg_telemetry.cpp
@@ -57,15 +57,15 @@ public:
 
 		can_msg_t invalid_type_msg = msg;
 		invalid_type_msg.sid = build_sid(prio_before, MSG_SENSOR_ANALOG32, 0);
-		w_status_t parse_status =
-			get_telemetry_info_msg(&invalid_type_msg, &channel_id_after, &lqi_after, &rssi_after);
-		rockettest_check_expr_true(parse_status == W_INVALID_PARAM);
+		rockettest_check_expr_true(
+			get_telemetry_info_msg(&invalid_type_msg, &channel_id_after, &lqi_after, &rssi_after) ==
+			W_INVALID_PARAM);
 
 		can_msg_t invalid_len_msg = msg;
 		invalid_len_msg.data_len = 3;
-		parse_status =
-			get_telemetry_info_msg(&invalid_len_msg, &channel_id_after, &lqi_after, &rssi_after);
-		rockettest_check_expr_true(parse_status == W_DATA_FORMAT_ERROR);
+		rockettest_check_expr_true(
+			get_telemetry_info_msg(&invalid_len_msg, &channel_id_after, &lqi_after, &rssi_after) ==
+			W_DATA_FORMAT_ERROR);
 
 		return test_passed;
 	}


### PR DESCRIPTION
…issing. Also get rid of extra parse_status variable, just check function call directly for readability and consistency.

Fix #175 